### PR TITLE
Fix for the naming of the new bus/trafo/line in SH scenario

### DIFF
--- a/etrago/extras/utilities.py
+++ b/etrago/extras/utilities.py
@@ -126,9 +126,12 @@ def load_shedding (network, **kwargs):
 def data_manipulation_sh (network):
 
     #add connection from Luebeck to Siems
-    network.add("Bus", "Siems220",carrier='AC', v_nom=220, x=10.760835, y=53.909745)
-    network.add("Transformer", "Siems220_380", bus0="25536", bus1="Siems220", x=1.29960, tap_ratio=1, s_nom=1600)
-    network.add("Line","LuebeckSiems", bus0="26387",bus1="Siems220", x=0.0001, s_nom=1600)
+    new_bus = str(int(network.buses.index.max())+1)
+    new_trafo = str(int(network.transformers.index.max())+1)
+    new_line = str(int(network.lines.index.max())+1)
+    network.add("Bus", new_bus,carrier='AC', v_nom=220, x=10.760835, y=53.909745)
+    network.add("Transformer", new_trafo, bus0="25536", bus1=new_bus, x=1.29960, tap_ratio=1, s_nom=1600)
+    network.add("Line",new_line, bus0="26387",bus1=new_bus, x=0.0001, s_nom=1600)
     
     return
     


### PR DESCRIPTION
In the function data_manipulation_sh() the newly added components don't use integers as IDs which can cause problems with other future functions (e.g. export result back to the database).
Therefore, the new components will get a new unique ID which is being generated from the highest last used ID in the available data set.