### PR TITLE
Feature/reinclude carriers network obj

### DIFF
--- a/etrago/tools/config.json
+++ b/etrago/tools/config.json
@@ -15,7 +15,8 @@
 	"Storage":
        	{
 	    "StoragePqSet": ["p_set"]
-	}
+	},
+	"Source": null
     },
     "pf":
     {

--- a/etrago/tools/config.json
+++ b/etrago/tools/config.json
@@ -15,8 +15,7 @@
 	"Storage":
        	{
 	    "StoragePqSet": ["p_set"]
-	},
-	"Source": null
+	}
     },
     "pf":
     {

--- a/etrago/tools/io.py
+++ b/etrago/tools/io.py
@@ -142,7 +142,7 @@ class NetworkScenario(ScenarioBase):
         # TODO column naming in database
         return {k.source_id: k.name for k in query.all()}
 
-    def by_scenario(self, name):
+    def fetch_by_relname(self, name):
         """
         """
 
@@ -170,7 +170,7 @@ class NetworkScenario(ScenarioBase):
 
         return df
 
-    def series_by_scenario(self, name, column):
+    def series_fetch_by_relname(self, name, column):
         """
         """
 
@@ -254,7 +254,7 @@ class NetworkScenario(ScenarioBase):
 
             pypsa_comp_name = tablename[comp] if comp in tablename else comp
 
-            df = self.by_scenario(comp)
+            df = self.fetch_by_relname(comp)
 
             if comp in old_to_new_name:
 
@@ -269,7 +269,7 @@ class NetworkScenario(ScenarioBase):
 
                     for col in columns:
 
-                        df_series = self.series_by_scenario(comp_t, col)
+                        df_series = self.series_fetch_by_relname(comp_t, col)
 
                         # TODO: VMagPuSet?
                         if timevarying_override and comp == 'Generator':
@@ -288,6 +288,10 @@ class NetworkScenario(ScenarioBase):
                         except (ValueError, AttributeError):
                             print("Series %s of component %s could not be "
                                   "imported" % (col, pypsa_comp_name))
+
+        # populate carrier attribute in PyPSA network
+        network.import_components_from_dataframe(
+            self.fetch_by_relname(carr_ormclass), 'Carrier')
 
         self.network = network
 

--- a/etrago/tools/io.py
+++ b/etrago/tools/io.py
@@ -147,8 +147,12 @@ class NetworkScenario(ScenarioBase):
         """
 
         ormclass = self._mapped[name]
-        query = self.session.query(ormclass).filter(
-            ormclass.scn_name == self.scn_name)
+        query = self.session.query(ormclass)
+
+        if name != carr_ormclass:
+
+            query = query.filter(
+                ormclass.scn_name == self.scn_name)
 
         if self.version:
             query = query.filter(ormclass.version == self.version)
@@ -246,7 +250,9 @@ class NetworkScenario(ScenarioBase):
         for comp, comp_t_dict in self.config.items():
 
             # TODO: This is confusing, should be fixed in db
-            pypsa_comp_name = 'StorageUnit' if comp == 'Storage' else comp
+            tablename = {'Storage': 'StorageUnit', 'Source': 'Carrier'}
+
+            pypsa_comp_name = tablename[comp] if comp in tablename else comp
 
             df = self.by_scenario(comp)
 

--- a/etrago/tools/io.py
+++ b/etrago/tools/io.py
@@ -250,9 +250,7 @@ class NetworkScenario(ScenarioBase):
         for comp, comp_t_dict in self.config.items():
 
             # TODO: This is confusing, should be fixed in db
-            tablename = {'Storage': 'StorageUnit', 'Source': 'Carrier'}
-
-            pypsa_comp_name = tablename[comp] if comp in tablename else comp
+            pypsa_comp_name = 'StorageUnit' if comp == 'Storage' else comp
 
             df = self.fetch_by_relname(comp)
 


### PR DESCRIPTION
Related to #84 

After network creation network.carriers is of the following form. Is this correct? 

||   co2_emissions| commentary |                name | version|
|---|---|---|---|--|
|1 |            NaN    |   None   |               gas | v0.2.11|
|2|...|||
...

