### PR TITLE
Upgrade to pypsa 11

### DIFF
--- a/etrago/appl.py
+++ b/etrago/appl.py
@@ -39,12 +39,12 @@ args = {# Setup and Configuration:
         'method': 'lopf', # lopf or pf
         'pf_post_lopf': False, # state whether you want to perform a pf after a lopf simulation
         'start_snapshot': 1, 
-        'end_snapshot' : 8760,
-        'scn_name': 'NEP 2035', # state which scenario you want to run: Status Quo, NEP 2035, eGo100
-        'solver': 'gurobi', # glpk, cplex or gurobi
+        'end_snapshot' : 2,
+        'scn_name': 'SH Status Quo', # state which scenario you want to run: Status Quo, NEP 2035, eGo100
+        'solver': 'glpk', # glpk, cplex or gurobi
         # Export options:
         'lpfile': False, # state if and where you want to save pyomo's lp file: False or /path/tofolder
-        'results': '/home/openego/pf_results/storage_paper/k50year', # state if and where you want to save results as csv: False or /path/tofolder
+        'results': False, # state if and where you want to save results as csv: False or /path/tofolder
         'export': False, # state if you want to export the results back to the database
         # Settings:        
         'storage_extendable':True, # state if you want storages to be installed at each node if necessary.
@@ -52,11 +52,11 @@ args = {# Setup and Configuration:
         'reproduce_noise': False, # state if you want to use a predefined set of random noise for the given scenario. if so, provide path, e.g. 'noise_values.csv'
         'minimize_loading':False,
         # Clustering:
-        'k_mean_clustering': 50, # state if you want to perform a k-means clustering on the given network. State False or the value k (e.g. 20).
+        'k_mean_clustering': False, # state if you want to perform a k-means clustering on the given network. State False or the value k (e.g. 20).
         'network_clustering': False, # state if you want to perform a clustering of HV buses to EHV buses.
         # Simplifications:
         'parallelisation':False, # state if you want to run snapshots parallely.
-        'line_grouping': False, # state if you want to group lines running between the same buses.
+        'line_grouping': True, # state if you want to group lines running between the same buses.
         'branch_capacity_factor': 0.7, # globally extend or lower branch capacities
         'load_shedding':False, # meet the demand at very high cost; for debugging purposes.
         'comments':None }

--- a/etrago/cluster/networkclustering.py
+++ b/etrago/cluster/networkclustering.py
@@ -70,7 +70,7 @@ def cluster_on_extra_high_voltage(network, busmap, with_time=True):
     io.import_components_from_dataframe(network_c, transformers, "Transformer")
 
     if with_time:
-        network_c.now = network.now
+        network_c.snapshots = network.snapshots
         network_c.set_snapshots(network.snapshots)
 
     # dealing with generators

--- a/etrago/tools/io.py
+++ b/etrago/tools/io.py
@@ -967,6 +967,6 @@ def results_to_oedb(session, network, grid, args):
 
     
 if __name__ == '__main__':
-    if pypsa.__version__ not in ['0.6.2', '0.8.0']:
+    if pypsa.__version__ not in ['0.6.2', '0.11.0']:
         print('Pypsa version %s not supported.' % pypsa.__version__)
     pass

--- a/etrago/tools/io.py
+++ b/etrago/tools/io.py
@@ -220,9 +220,8 @@ class NetworkScenario(ScenarioBase):
         network.set_snapshots(self.timeindex)
 
         timevarying_override = False
-
+        
         if pypsa.__version__ == '0.11.0':
-
             old_to_new_name = {'Generator':
                                {'p_min_pu_fixed': 'p_min_pu',
                                 'p_max_pu_fixed': 'p_max_pu',

--- a/etrago/tools/io.py
+++ b/etrago/tools/io.py
@@ -212,7 +212,7 @@ class NetworkScenario(ScenarioBase):
 
         timevarying_override = False
 
-        if pypsa.__version__ == '0.8.0':
+        if pypsa.__version__ == '0.11.0':
 
             old_to_new_name = {'Generator':
                                {'p_min_pu_fixed': 'p_min_pu',


### PR DESCRIPTION
In eTraGo/io I changed the version number of pypsa, so components can be renamed and in networkclustering.py I changed network.now, that has been revomed in pypsa 0.9, to network.snasphots.
I tested it local and it worked.