### PR TITLE
Add shaply to install_requires setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(name='eTraGo',
                         'pypsa >= 0.11.0, <= 0.11.0',
                         'sqlalchemy >= 1.0.15, <= 1.1.4',
                         'geoalchemy2 >= 0.3.0, <=0.4.0',
-                        'matplotlib >= 1.5.3, <=1.5.3'],
+                        'matplotlib >= 1.5.3, <=1.5.3',
+		        'shapely >= 1.5.12, <= 1.6.3'],
 	  dependency_links=['git+https://git@github.com/openego/PyPSA.git@dev#egg=PyPSA'],
         extras_require={
         'docs': [


### PR DESCRIPTION
The python package shapely is missing in setup.py  install_requires.
After installing and using eTraGo in a clean environment for a single usage an import error of the missing package shapely appears. This should fix the error. 