### PR TITLE
Features/plotting

### DIFF
--- a/etrago/appl.py
+++ b/etrago/appl.py
@@ -71,7 +71,7 @@ args = {# Setup and Configuration:
         'reproduce_noise': False,# state if you want to use a predefined set of random noise for the given scenario. if so, provide path, e.g. 'noise_values.csv'
         'minimize_loading':False,
         # Clustering:
-        'network_clustering_kmeans':False, # state if you want to perform a k-means clustering on the given network. State False or the value k (e.g. 20).
+        'network_clustering_kmeans':20, # state if you want to perform a k-means clustering on the given network. State False or the value k (e.g. 20).
         'load_cluster': False, # state if you want to load cluster coordinates from a previous run: False or /path/tofile (filename similar to ./cluster_coord_k_n_result)
         'network_clustering_ehv': False, # state if you want to perform a clustering of HV buses to EHV buses.
         'snapshot_clustering':False, # False or the number of 'periods' you want to cluster to. Move to PyPSA branch:features/snapshot_clustering

--- a/etrago/appl.py
+++ b/etrago/appl.py
@@ -36,7 +36,8 @@ if not 'READTHEDOCS' in os.environ:
     from etrago.tools.io import NetworkScenario, results_to_oedb, extension, decommissioning
     from etrago.tools.plot import (plot_line_loading, plot_stacked_gen,
                                      add_coordinates, curtailment, gen_dist,
-                                     storage_distribution, storage_expansion, extension_overlay_network)
+                                     storage_distribution, storage_expansion, 
+                                     extension_overlay_network, nodal_gen_dispatch)
 
     from etrago.tools.utilities import (load_shedding, data_manipulation_sh, convert_capital_costs,
                                     results_to_csv, parallelisation, pf_post_lopf, 
@@ -49,7 +50,7 @@ if not 'READTHEDOCS' in os.environ:
 
 args = {# Setup and Configuration:
         'db': 'oedb', # db session
-        'gridversion': 'v0.3.1', # None for model_draft or Version number (e.g. v0.2.11) for grid schema
+        'gridversion': 'v0.3.2', # None for model_draft or Version number (e.g. v0.2.11) for grid schema
         'method': 'lopf', # lopf or pf
         'pf_post_lopf': False, # state whether you want to perform a pf after a lopf simulation
         'start_snapshot': 2880,
@@ -73,7 +74,7 @@ args = {# Setup and Configuration:
         'network_clustering_kmeans':10, # state if you want to perform a k-means clustering on the given network. State False or the value k (e.g. 20).
         'load_cluster': False, # state if you want to load cluster coordinates from a previous run: False or /path/tofile (filename similar to ./cluster_coord_k_n_result)
         'network_clustering_ehv': False, # state if you want to perform a clustering of HV buses to EHV buses.
-        'snapshot_clustering':3, # False or the number of 'periods' you want to cluster to. Move to PyPSA branch:features/snapshot_clustering
+        'snapshot_clustering':False, # False or the number of 'periods' you want to cluster to. Move to PyPSA branch:features/snapshot_clustering
         # Simplifications:
         'parallelisation':False, # state if you want to run snapshots parallely.
         'skip_snapshots':False,

--- a/etrago/tools/plot.py
+++ b/etrago/tools/plot.py
@@ -51,6 +51,31 @@ def add_coordinates(network):
         network.buses.loc[idx, 'y'] = wkt_geom.y
 
     return network
+
+def coloring():
+    colors = {'biomass':'green',
+              'coal':'k',
+              'gas':'orange',
+              'eeg_gas':'olive',
+              'geothermal':'purple',
+              'lignite':'brown',
+              'oil':'darkgrey',
+              'other_non_renewable':'pink',
+              'reservoir':'navy',
+              'run_of_river':'aqua',
+              'pumped_storage':'steelblue',
+              'solar':'yellow',
+              'uranium':'lime',
+              'waste':'sienna',
+              'wind':'blue',
+              'wind_onshore':'skyblue',
+              'wind_offshore':'brightblue',
+              'slack':'pink',
+              'load shedding': 'red',
+              'nan':'m',
+              'imports':'salmon',
+              '':'m'}
+    return colors
     
 def plot_line_loading(network, timesteps=range(1,2), filename=None, boundaries=[],
                       arrows= False ):
@@ -481,27 +506,7 @@ def plot_stacked_gen(network, bus=None, resolution='GW', filename=None):
         filtered_load = network.loads[network.loads['bus'] == bus]
         load = network.loads_t.p[filtered_load.index]
 
-    colors = {'biomass':'green',
-              'coal':'k',
-              'gas':'orange',
-              'eeg_gas':'olive',
-              'geothermal':'purple',
-              'lignite':'brown',
-              'oil':'darkgrey',
-              'other_non_renewable':'pink',
-              'reservoir':'navy',
-              'run_of_river':'aqua',
-              'pumped_storage':'steelblue',
-              'solar':'yellow',
-              'uranium':'lime',
-              'waste':'sienna',
-              'wind':'skyblue',
-              'slack':'pink',
-              'load shedding': 'red',
-              'nan':'m',
-              'imports':'salmon',
-              '':'m'}
-
+    colors = coloring()
 #    TODO: column reordering based on available columns
 
     fig,ax = plt.subplots(1,1)
@@ -555,24 +560,7 @@ def plot_gen_diff(networkA, networkB, leave_out_carriers=['geothermal', 'oil',
     gen_switches = gen_by_c(networkA)
     diff = gen_switches-gen
     
-    colors = {'biomass':'green',
-          'coal':'k',
-          'gas':'orange',
-          'eeg_gas':'olive',
-          'geothermal':'purple',
-          'lignite':'brown',
-          'oil':'darkgrey',
-          'other_non_renewable':'pink',
-          'reservoir':'navy',
-          'run_of_river':'aqua',
-          'pumped_storage':'steelblue',
-          'solar':'yellow',
-          'uranium':'lime',
-          'waste':'sienna',
-          'wind':'skyblue',
-          'slack':'pink',
-          'load shedding': 'red',
-          'nan':'m'}
+    colors = coloring()
     diff.drop(leave_out_carriers, axis=1, inplace=True)
     colors = [colors[col] for col in diff.columns]
     
@@ -976,24 +964,7 @@ def nodal_gen_dispatch(network,scaling=False, techs= ['wind_onshore', 'solar'], 
     
     gens = network.generators[network.generators.carrier.isin(techs)]
     dispatch =network.generators_t.p[gens.index].mul(network.snapshot_weightings, axis=0).sum().groupby([network.generators.bus, network.generators.carrier]).sum() * network.snapshot_weightings[1]
-    colors = {'biomass':'green',
-              'coal':'k',
-              'gas':'orange',
-              'eeg_gas':'olive',
-              'geothermal':'purple',
-              'lignite':'brown',
-              'oil':'darkgrey',
-              'other_non_renewable':'pink',
-              'reservoir':'navy',
-              'run_of_river':'aqua',
-              'pumped_storage':'steelblue',
-              'solar':'yellow',
-              'uranium':'lime',
-              'waste':'sienna',
-              'wind_onshore':'skyblue',
-              'slack':'pink',
-              'load shedding': 'red',
-              'nan':'m'}
+    colors = coloring()
               
     subcolors={a:colors[a] for a in techs}#network.generators.carrier.unique()}
     

--- a/etrago/tools/plot.py
+++ b/etrago/tools/plot.py
@@ -52,7 +52,7 @@ def add_coordinates(network):
 
     return network
     
-def plot_line_loading(network, timestep=0, filename=None, boundaries=[],
+def plot_line_loading(network, timesteps=range(1,2), filename=None, boundaries=[],
                       arrows= False ):
     """
     Plot line loading as color on lines
@@ -76,20 +76,26 @@ def plot_line_loading(network, timestep=0, filename=None, boundaries=[],
     if network.lines_t.q0.empty:
         array_line = [['Line'] * len(network.lines), network.lines.index]
     
-        loading_lines = pd.Series(abs((network.lines_t.p0.loc[network.snapshots[timestep]]/ \
-                   (network.lines.s_nom)) * 100).data, index = array_line)
+        loading_lines = pd.Series((network.lines_t.p0.loc[network.snapshots[timesteps]].abs().sum()/ \
+                   (network.lines.s_nom)).data, index = array_line)
+                  
+        load_lines_rel = (loading_lines/network.snapshots[timesteps].size)*100
+
     
         array_link = [['Link'] * len(network.links), network.links.index]
     
-        loading_links = pd.Series(abs((network.links_t.p0.loc[network.snapshots[timestep]]/ \
-                   (network.links.p_nom)) * 100).data, index = array_link)
+        loading_links = pd.Series((network.links_t.p0.loc[network.snapshots[timesteps]].abs().sum()/ \
+                   (network.links.p_nom)).data, index = array_link)
+
+        load_links_rel = (loading_links/network.snapshots[timesteps].size)*100
+
     
-        loading = loading_lines.append(loading_links)
+        loading = load_lines_rel.append(load_links_rel)
         
     else:
-         loading = ((network.lines_t.p0.loc[network.snapshots[timestep]] ** 2 +
-                   network.lines_t.q0.loc[network.snapshots[timestep]] ** 2).\
-                   apply(sqrt) / (network.lines.s_nom)) * 100 
+         loading = ((network.lines_t.p0.loc[network.snapshots[timesteps]].abs().sum() ** 2 +
+                   network.lines_t.q0.loc[network.snapshots[timesteps]].abs().sum() ** 2).\
+                   apply(sqrt) / ((network.lines.s_nom)*network.snapshots[timesteps].size)) * 100 
 
     # do the plotting
 

--- a/etrago/tools/plot.py
+++ b/etrago/tools/plot.py
@@ -975,7 +975,7 @@ def gen_dist(network, techs=None, snapshot=1, n_cols=3,gen_size=0.2, filename=No
 def nodal_gen_dispatch(network,scaling=False, techs= ['wind_onshore', 'solar'], filename=None):
     
     gens = network.generators[network.generators.carrier.isin(techs)]
-    dispatch =network.generators_t.p[gens.index].sum().groupby([network.generators.bus, network.generators.carrier]).sum() * network.snapshot_weightings[1]
+    dispatch =network.generators_t.p[gens.index].mul(network.snapshot_weightings, axis=0).sum().groupby([network.generators.bus, network.generators.carrier]).sum() * network.snapshot_weightings[1]
     colors = {'biomass':'green',
               'coal':'k',
               'gas':'orange',


### PR DESCRIPTION
The plots `storage_distribution` and `storage_expansion` got a legend now. Furthermore the attribute `scaling` can be used to set the sizing of the bubbles.

Furthermore a new plot was developed to plot the nodal generation over the entire period of time calculated as a pie per node where it can be specified which generation carrier one want to plot. This plot is still missing a legend due to this [issue](https://github.com/PyPSA/PyPSA/issues/32#issuecomment-383000409).

The `plot_line_loading` can now also plot the average loading over a period of time by specifying the range of snapshots you want to look at. To reproduce the old functionality of just plotting the results for one particular snapshot one has to state `timesteps=range(x,x+1)` instead of `timesteps=x`