### PR TITLE
bugfix - add .abs() in plot.py, calc_ac_loading function

### DIFF
--- a/etrago/tools/plot.py
+++ b/etrago/tools/plot.py
@@ -1149,7 +1149,7 @@ def calc_ac_loading(network, timesteps):
     """
 
     loading_lines = mul_weighting(network, network.lines_t.p0).loc[
-                network.snapshots[timesteps]].sum()
+                network.snapshots[timesteps]].abs().sum()
 
     if not network.lines_t.q0.empty:
 


### PR DESCRIPTION
Hi Clara and Ulf,

I hope you are doing well :)

Does there not have to be such an .abs() to be added as proposed in the commit? Because the average shall be calculated over both negative and positive flows. In line 1158 at the calculation for q0 there is also such an .abs() included: mul_weighting(network, network.lines_t.q0).loc[network.snapshots[timesteps]].abs().sum()

Or am I wrong?

Cheers Wilko 