### PR TITLE
Close session at the end of run_etrago

### DIFF
--- a/etrago/appl.py
+++ b/etrago/appl.py
@@ -370,6 +370,7 @@ if __name__ == '__main__':
     print(datetime.datetime.now())
     etrago = run_etrago(args, json_path=None)
     print(datetime.datetime.now())
+    etrago.session.close()
     # plots
     # make a line loading plot
     # plot_line_loading(network)


### PR DESCRIPTION
This prevents the following problem: 

```
> ERROR:sqlalchemy.pool.QueuePool:Exception during reset or similar
> Traceback (most recent call last):
>   File "/home/clara/venv/new-etrago/lib/python3.7/site-packages/sqlalchemy/pool.py", line 703, in _finalize_fairy
>     fairy._reset(pool)
>   File "/home/clara/venv/new-etrago/lib/python3.7/site-packages/sqlalchemy/pool.py", line 873, in _reset
>     pool._dialect.do_rollback(self)
>   File "/home/clara/venv/new-etrago/lib/python3.7/site-packages/sqlalchemy/engine/default.py", line 457, in do_rollback
>     dbapi_connection.rollback()
>   File "/home/clara/venv/new-etrago/lib/python3.7/site-packages/oedialect/engine.py", line 61, in rollback
>     requires_connection_id=True)
>   File "/home/clara/venv/new-etrago/lib/python3.7/site-packages/oedialect/engine.py", line 225, in post
>     headers=header, verify=verify)
>   File "/home/clara/venv/new-etrago/lib/python3.7/site-packages/requests/api.py", line 119, in post
>     return request('post', url, data=data, json=json, **kwargs)
>   File "/home/clara/venv/new-etrago/lib/python3.7/site-packages/requests/api.py", line 61, in request
>     return session.request(method=method, url=url, **kwargs)
>   File "/home/clara/venv/new-etrago/lib/python3.7/site-packages/requests/sessions.py", line 542, in request
>     resp = self.send(prep, **send_kwargs)
>   File "/home/clara/venv/new-etrago/lib/python3.7/site-packages/requests/sessions.py", line 655, in send
>     r = adapter.send(request, **kwargs)
>   File "/home/clara/venv/new-etrago/lib/python3.7/site-packages/requests/adapters.py", line 449, in send
>     timeout=timeout
>   File "/home/clara/venv/new-etrago/lib/python3.7/site-packages/urllib3/connectionpool.py", line 706, in urlopen
>     chunked=chunked,
>   File "/home/clara/venv/new-etrago/lib/python3.7/site-packages/urllib3/connectionpool.py", line 382, in _make_request
>     self._validate_conn(conn)
>   File "/home/clara/venv/new-etrago/lib/python3.7/site-packages/urllib3/connectionpool.py", line 1010, in _validate_conn
>     conn.connect()
>   File "/home/clara/venv/new-etrago/lib/python3.7/site-packages/urllib3/connection.py", line 377, in connect
>     is_time_off = datetime.date.today() < RECENT_DATE
> ImportError: sys.meta_path is None, Python is likely shutting down
```
