### PR TITLE
Features/#322 snapshot clustering constraints without pyomo

### DIFF
--- a/etrago/appl.py
+++ b/etrago/appl.py
@@ -50,13 +50,13 @@ args = {
     'method': { # Choose method and settings for optimization
         'type': 'lopf', # type of optimization, currently only 'lopf'
         'n_iter': 2, # abort criterion of iterative optimization, 'n_iter' or 'threshold'
-        'pyomo': True}, # set if pyomo is used for model building
+        'pyomo': False}, # set if pyomo is used for model building
     'pf_post_lopf': {
         'active': False, # choose if perform a pf after a lopf simulation
         'add_foreign_lopf': True, # keep results of lopf for foreign DC-links
         'q_allocation': 'p_nom'}, # allocate reactive power via 'p_nom' or 'p'
     'start_snapshot': 1,
-    'end_snapshot': 3,
+    'end_snapshot': 240,
     'solver': 'gurobi',  # glpk, cplex or gurobi
     'solver_options': { # {} for default options, specific for solver
         'BarConvTol': 1.e-5,
@@ -93,8 +93,8 @@ args = {
     'network_clustering_ehv': False,  # clustering of HV buses to EHV buses.
     'disaggregation': None,  # None, 'mini' or 'uniform'
     'snapshot_clustering': {
-        'active': False, # choose if clustering is activated
-        'n_clusters': 2, # number of periods
+        'active': True, # choose if clustering is activated
+        'n_clusters': 5, # number of periods
         'how': 'daily', # type of period, currently only 'daily'
         'storage_constraints': 'soc_constraints'}, # additional constraints for storages
     # Simplifications:
@@ -337,6 +337,10 @@ def run_etrago(args, json_path):
 
     # adjust network, e.g. set (n-1)-security factor
     etrago.adjust_network()
+    
+    etrago.network.storage_units.efficiency_dispatch = 1
+    etrago.network.storage_units.efficiency_store = 1
+    etrago.network.storage_units.standing_loss = 0
 
     # ehv network clustering
     etrago.ehv_clustering()

--- a/etrago/appl.py
+++ b/etrago/appl.py
@@ -56,7 +56,7 @@ args = {
         'add_foreign_lopf': True, # keep results of lopf for foreign DC-links
         'q_allocation': 'p_nom'}, # allocate reactive power via 'p_nom' or 'p'
     'start_snapshot': 1,
-    'end_snapshot': 240,
+    'end_snapshot': 3,
     'solver': 'gurobi',  # glpk, cplex or gurobi
     'solver_options': { # {} for default options, specific for solver
         'BarConvTol': 1.e-5,
@@ -93,8 +93,8 @@ args = {
     'network_clustering_ehv': False,  # clustering of HV buses to EHV buses.
     'disaggregation': None,  # None, 'mini' or 'uniform'
     'snapshot_clustering': {
-        'active': True, # choose if clustering is activated
-        'n_clusters': 5, # number of periods
+        'active': False, # choose if clustering is activated
+        'n_clusters': 2, # number of periods
         'how': 'daily', # type of period, currently only 'daily'
         'storage_constraints': 'soc_constraints'}, # additional constraints for storages
     # Simplifications:
@@ -337,10 +337,6 @@ def run_etrago(args, json_path):
 
     # adjust network, e.g. set (n-1)-security factor
     etrago.adjust_network()
-    
-    etrago.network.storage_units.efficiency_dispatch = 1
-    etrago.network.storage_units.efficiency_store = 1
-    etrago.network.storage_units.standing_loss = 0
 
     # ehv network clustering
     etrago.ehv_clustering()

--- a/etrago/cluster/snapshot.py
+++ b/etrago/cluster/snapshot.py
@@ -148,17 +148,21 @@ def tsam_cluster(timeseries_df,
     for i in clusterOrder:
         representative_day.append(dic_clusterCenterIndices[i])
 
-    #get list of last hour of representative days
+    #get list of last and first hour of representative days
     last_hour_datetime=[]
+    first_hour_datetime=[]
     for i in representative_day:
         last_hour = i * hours + hours - 1
         last_hour_datetime.append(timeseries_df.index[last_hour])
+        first_hour = i * hours + hours - hours
+        first_hour_datetime.append(timeseries_df.index[first_hour])
 
     #create a dataframe (index=nr. of day in a year/candidate)
     df_cluster =  pd.DataFrame({
                         'Cluster': clusterOrder, #Cluster of the day
                         'RepresentativeDay': representative_day, #representative day of the cluster
-                        'last_hour_RepresentativeDay': last_hour_datetime}) #last hour of the cluster
+                        'last_hour_RepresentativeDay': last_hour_datetime,
+                        'first_hour_RepresentativeDay': first_hour_datetime}) #last hour of the cluster
     df_cluster.index = df_cluster.index + 1
     df_cluster.index.name = 'Candidate'
 
@@ -188,7 +192,7 @@ def run(network, n_clusters=None, how='daily',
                 prepare_pypsa_timeseries(network),
                 typical_periods=n_clusters,
                 how='daily',
-                extremePeriodMethod = 'None')
+                extremePeriodMethod = 'None') #'new_cluster_center'
     network.cluster = df_cluster
     network.cluster_ts = df_i_h
 

--- a/etrago/cluster/snapshot.py
+++ b/etrago/cluster/snapshot.py
@@ -193,6 +193,9 @@ def run(network, n_clusters=None, how='daily',
     network.cluster_ts = df_i_h
 
     update_data_frames(network, cluster_weights, dates, hours)
+    
+    network.snapshots = network.snapshots.sort_values()
+    network.snapshot_weightings = network.snapshot_weightings.sort_values()
 
     return network
 

--- a/etrago/cluster/snapshot.py
+++ b/etrago/cluster/snapshot.py
@@ -192,7 +192,7 @@ def run(network, n_clusters=None, how='daily',
                 prepare_pypsa_timeseries(network),
                 typical_periods=n_clusters,
                 how='daily',
-                extremePeriodMethod = 'None') #'new_cluster_center'
+                extremePeriodMethod = 'None') 
     network.cluster = df_cluster
     network.cluster_ts = df_i_h
 

--- a/etrago/cluster/snapshot.py
+++ b/etrago/cluster/snapshot.py
@@ -154,7 +154,7 @@ def tsam_cluster(timeseries_df,
     for i in representative_day:
         last_hour = i * hours + hours - 1
         last_hour_datetime.append(timeseries_df.index[last_hour])
-        first_hour = i * hours + hours - hours
+        first_hour = i * hours 
         first_hour_datetime.append(timeseries_df.index[first_hour])
 
     #create a dataframe (index=nr. of day in a year/candidate)
@@ -192,7 +192,7 @@ def run(network, n_clusters=None, how='daily',
                 prepare_pypsa_timeseries(network),
                 typical_periods=n_clusters,
                 how='daily',
-                extremePeriodMethod = 'None') 
+                extremePeriodMethod = 'None')
     network.cluster = df_cluster
     network.cluster_ts = df_i_h
 

--- a/etrago/tools/constraints.py
+++ b/etrago/tools/constraints.py
@@ -1149,8 +1149,6 @@ def snapshot_clustering_seasonal_storage(self, network, snapshots):
             p_nom = m.storage_p_nom[s]
         else:
             p_nom = network.storage_units.p_nom[s]
-            
-        import pdb; pdb.set_trace()
 
         return (m.state_of_charge_intra[s, intra_hour] +
                 m.state_of_charge_inter[s, network.cluster_ts['Candidate_day'][h]]

--- a/etrago/tools/constraints.py
+++ b/etrago/tools/constraints.py
@@ -25,6 +25,7 @@ import logging
 from pyomo.environ import Constraint
 import pandas as pd
 import pyomo.environ as po
+import numpy as np
 from pypsa.linopt import get_var, linexpr, define_constraints, define_variables
 from pypsa.descriptors import expand_series
 from pypsa.pf import get_switchable_as_dense as get_as_dense
@@ -1200,13 +1201,12 @@ def snapshot_clustering_seasonal_storage_nmp(self, n, sns):
     c = 'StorageUnit'
 
     period_starts = sns[0::24]
-    other_sns = sns[sns.hour>0]
 
 
     candidates = \
         n.cluster.index.get_level_values(0).unique()
 
-    import numpy as np
+
 
     soc_total = get_var(n, c, 'state_of_charge')
 
@@ -1247,9 +1247,7 @@ def snapshot_clustering_seasonal_storage_nmp(self, n, sns):
 
     define_constraints(n, lhs, '==', 0, c, 'soc_inter_constraints')
 
-
-
-
+    # Define soc_intra
     # Set lower and upper bound for soc_intra
     lb = pd.DataFrame(index=sns, columns=sus.index, data=-np.inf)
     ub = pd.DataFrame(index=sns, columns=sus.index, data=np.inf)
@@ -1258,41 +1256,9 @@ def snapshot_clustering_seasonal_storage_nmp(self, n, sns):
     lb.loc[period_starts, :] = 0
     ub.loc[period_starts, :] = 0
 
-    # # Create intra soc variable for each storage and each hour
+    # Create intra soc variable for each storage and each hour
     define_variables(n, lb, ub, 'StorageUnit', 'soc_intra')
-
-    # eh = expand_series(n.snapshot_weightings[sns], sus.index) #elapsed hours
-
-    # eff_stand = expand_series(1-n.df(c).standing_loss, sns).T.pow(eh)
-    # eff_dispatch = expand_series(n.df(c).efficiency_dispatch, sns).T
-    # eff_store = expand_series(n.df(c).efficiency_store, sns).T
-
     soc_intra = get_var(n, c, 'soc_intra')
-    # cyclic_i = n.df(c).query('cyclic_state_of_charge').index
-
-    # prev_soc_cyclic = soc_intra.shift().fillna(soc_intra.loc[sns[-1]])
-
-    # coeff_var = [(-1, soc_intra),
-    #              (-1/eff_dispatch * eh, get_var(n, c, 'p_dispatch')),
-    #              (eff_store * eh, get_var(n, c, 'p_store'))]
-
-    # lhs, *axes = linexpr(*coeff_var, return_axes=True)
-
-    # def masked_term(coeff, var, cols):
-    #     return linexpr((coeff[cols], var[cols]))\
-    #            .reindex(index=axes[0], columns=axes[1], fill_value='').values
-
-    # lhs += masked_term(eff_stand, prev_soc_cyclic, cyclic_i)
-
-    # rhs = -get_as_dense(n, c, 'inflow', sns).mul(eh)
-
-    # define_constraints(n, lhs, '==', rhs, c, 'mu_soc_intra')
-
-    # network = n
-
-
-    # Total state of charge
-
 
     coeff_var = [(-1, soc_total),
                  (1, soc_intra),
@@ -1302,97 +1268,6 @@ def snapshot_clustering_seasonal_storage_nmp(self, n, sns):
 
     define_constraints(n, lhs, '==', 0, c, 'soc_intra_constraints')
 
-
-    # import pdb; pdb.set_trace()
-    # def state_of_charge_lower(m, s, h):
-    #     """
-    #     Define the state_of_charge as the sum of state_of_charge_inter
-    #     and state_of_charge_intra
-
-    #     According to:
-    #     L. Kotzur et al: 'Time series aggregation for energy system design:
-    #     Modeling seasonal storage', 2018
-    #     """
-
-    #   # Choose datetime of representive day
-    #     date = str(network.snapshots[
-    #         network.snapshots.dayofyear -1 ==
-    #         network.cluster['RepresentativeDay'][h.dayofyear]][0]).split(' ')[0]
-    #     hour = str(h).split(' ')[1]
-
-    #     intra_hour = pd.to_datetime(date + ' ' + hour)
-
-    #     return(m.state_of_charge_intra[s, intra_hour] +
-    #            m.state_of_charge_inter[s, network.cluster_ts['Candidate_day'][h]]
-    #            # * (1 - network.storage_units.at
-    #            # [s, 'standing_loss']*elapsed_hours)**24
-    #            >= 0)
-
-    # network.model.state_of_charge_lower = po.Constraint(
-    #     sus.index, network.cluster_ts.index, rule=state_of_charge_lower)
-
-    # network.model.del_component('state_of_charge_upper')
-    # network.model.del_component('state_of_charge_upper_index')
-    # network.model.del_component('state_of_charge_upper_index_0')
-    # network.model.del_component('state_of_charge_upper_index_1')
-
-    # def state_of_charge_upper(m, s, h):
-    #     date = str(network.snapshots[
-    #         network.snapshots.dayofyear -1 ==
-    #         network.cluster['RepresentativeDay'][h.dayofyear]][0]).split(' ')[0]
-
-    #     hour = str(h).split(' ')[1]
-
-    #     intra_hour = pd.to_datetime(date + ' ' + hour)
-
-    #     if network.storage_units.p_nom_extendable[s]:
-    #         p_nom = m.storage_p_nom[s]
-    #     else:
-    #         p_nom = network.storage_units.p_nom[s]
-
-    #     return (m.state_of_charge_intra[s, intra_hour] +
-    #             m.state_of_charge_inter[s, network.cluster_ts['Candidate_day'][h]]
-    #             # * (1 - network.storage_units.at[s,
-    #             # 'standing_loss']*elapsed_hours)**24
-    #             <= p_nom * network.storage_units.at[s, 'max_hours'])
-
-    # network.model.state_of_charge_upper = po.Constraint(
-    #     sus.index, network.cluster_ts.index,
-    #     rule=state_of_charge_upper)
-
-    # def cyclic_state_of_charge(m, s):
-    #     """
-    #     Defines cyclic condition like pypsas 'state_of_charge_contraint'.
-    #     There are small differences to original results.
-    #     """
-    #     last_day = network.cluster.index[-1]
-
-    #     last_calc_hour = network.cluster[
-    #         'last_hour_RepresentativeDay'][last_day]
-
-    #     last_inter = m.state_of_charge_inter[s, last_day]
-
-    #     last_intra = m.state_of_charge_intra[s, last_calc_hour]
-
-    #     first_day = network.cluster.index[0]
-
-    #     first_calc_hour = network.cluster[
-    #         'last_hour_RepresentativeDay'][first_day] - pd.DateOffset(hours=23)
-
-    #     first_inter = m.state_of_charge_inter[s, first_day]
-
-    #     first_intra = m.state_of_charge_intra[s, first_calc_hour]
-
-    #     return  (first_intra + first_inter == \
-    #            ((last_intra + last_inter)
-    #             * (1 - network.storage_units.at[s, 'standing_loss'])
-    #             -(m.storage_p_dispatch[s, last_calc_hour]/
-    #               network.storage_units.at[s, 'efficiency_dispatch']
-    #               -m.storage_p_store[s, last_calc_hour] *
-    #               network.storage_units.at[s, 'efficiency_store'])))
-
-    # network.model.cyclic_storage_constraint = po.Constraint(
-    #     sus.index, rule=cyclic_state_of_charge)
 
 class Constraints:
 

--- a/etrago/tools/constraints.py
+++ b/etrago/tools/constraints.py
@@ -1226,15 +1226,13 @@ def snapshot_clustering_seasonal_storage_nmp(self, n, sns):
 
     eff_stand = expand_series(1-n.df(c).standing_loss, candidates).T
 
-
     eff_dispatch = expand_series(n.df(c).efficiency_dispatch, candidates).T
     eff_store = expand_series(n.df(c).efficiency_store, candidates).T
 
     dispatch =  get_var(n, c, 'p_dispatch').loc[last_hour].set_index(candidates)
     store = get_var(n, c, 'p_store').loc[last_hour].set_index(candidates)
     last_soc_total = soc_total.loc[last_hour].set_index(candidates)
-    last_soc_inter = soc_inter.shift(1).fillna(soc_inter.loc[candidates[0]])
-
+    last_soc_inter = soc_inter.shift(1).fillna(soc_inter.loc[candidates[-1]])
 
     coeff_var = [(-1, next_soc_inter),
                  (eff_stand.pow(24), soc_inter),

--- a/etrago/tools/constraints.py
+++ b/etrago/tools/constraints.py
@@ -930,6 +930,233 @@ def _capacity_factor_per_gen_cntr_nmp(self, network, snapshots):
                                    '<=', arg[cntr][c][1]*potential,
                                    'Generator', 'max_flh_' + g)
 
+
+def snapshot_clustering_daily_bounds(self, network, snapshots):
+    # This will bound the storage level to 0.5 max_level every 24th hour.
+    sus = network.storage_units
+    # take every first hour of the clustered days
+    network.model.period_starts = \
+        network.snapshot_weightings.index[0::24]
+
+    network.model.storages = sus.index
+
+    print('Setting daily_bounds constraint')
+
+    def day_rule(m, s, p):
+        """
+        Sets the soc of the every first hour to the
+        soc of the last hour of the day (i.e. + 23 hours)
+        """
+        return (m.state_of_charge[s, p] ==
+                m.state_of_charge[s, p + pd.Timedelta(hours=23
+                                                      )])
+
+    network.model.period_bound = Constraint(
+        network.model.storages,
+        network.model.period_starts, rule=day_rule)
+
+def snapshot_clustering_seasonal_storage(self, network, snapshots):
+
+    sus = network.storage_units
+
+    network.model.period_starts = \
+        network.snapshot_weightings.index[0::24]
+
+    network.model.storages = sus.index
+
+    candidates = \
+        network.cluster.index.get_level_values(0).unique()
+
+    # create set for inter-temp constraints and variables
+    network.model.candidates = po.Set(
+        initialize=candidates, ordered=True)
+
+    # create intra soc variable for each storage and each hour
+    network.model.state_of_charge_intra = po.Var(
+        sus.index, network.snapshots)
+
+    def intra_soc_rule(m, s, h):
+        """
+        Sets soc_inter of first hour of every day to 0. Other hours
+        are set by technical coherences of storage units
+
+        According to:
+        L. Kotzur et al: 'Time series aggregation for energy
+        system design:
+        Modeling seasonal storage', 2018, equation no. 18
+        """
+
+        if h.hour == 0:
+            expr = (m.state_of_charge_intra[s, h] == 0)
+        else:
+            expr = (
+                m.state_of_charge_intra[s, h] ==
+                m.state_of_charge_intra[s, h-pd.DateOffset(hours=1)]
+                * (1 - network.storage_units.at[s, 'standing_loss'])
+                -(m.storage_p_dispatch[s, h-pd.DateOffset(hours=1)]/
+                  network.storage_units.at[s, 'efficiency_dispatch'] -
+                  network.storage_units.at[s, 'efficiency_store'] *
+                  m.storage_p_store[s, h-pd.DateOffset(hours=1)]))
+        return expr
+
+    network.model.soc_intra = po.Constraint(
+        network.model.storages, network.snapshots,
+        rule=intra_soc_rule)
+
+    # create inter soc variable for each storage and each candidate
+    network.model.state_of_charge_inter = po.Var(
+        sus.index, network.model.candidates,
+        within=po.NonNegativeReals)
+
+    def inter_storage_soc_rule(m, s, i):
+        """
+        Define the state_of_charge_inter as the state_of_charge_inter of
+        the day before minus the storage losses plus the state_of_charge_intra
+        of one hour after the last hour of the representative day.
+        For the last reperesentive day, the soc_inter is the same as
+        the first day due to cyclic soc condition
+
+        According to:
+        L. Kotzur et al: 'Time series aggregation for energy system design:
+        Modeling seasonal storage', 2018, equation no. 19
+        """
+
+        if i == network.model.candidates[-1]:
+            last_hour = network.cluster["last_hour_RepresentativeDay"][i]
+            expr = po.Constraint.Skip
+
+        else:
+            last_hour = network.cluster["last_hour_RepresentativeDay"][i]
+            expr = (
+                m.state_of_charge_inter[s, i+1] ==
+                m.state_of_charge_inter[s, i]
+                * (1 - network.storage_units.at[s, 'standing_loss'])**24
+                + m.state_of_charge_intra[s, last_hour]\
+                    * (1 - network.storage_units.at[s, 'standing_loss'])\
+                    -(m.storage_p_dispatch[s, last_hour]/\
+                    network.storage_units.at[s, 'efficiency_dispatch'] -
+                      network.storage_units.at[s, 'efficiency_store'] *
+                      m.storage_p_store[s, last_hour]))
+
+        return expr
+
+    network.model.inter_storage_soc_constraint = po.Constraint(
+        sus.index, network.model.candidates,
+        rule=inter_storage_soc_rule)
+
+    #new definition of the state_of_charge used in pypsa
+    network.model.del_component('state_of_charge_constraint')
+    network.model.del_component('state_of_charge_constraint_index')
+    network.model.del_component('state_of_charge_constraint_index_0')
+    network.model.del_component('state_of_charge_constraint_index_1')
+
+    def total_state_of_charge(m, s, h):
+        """
+        Define the state_of_charge as the sum of state_of_charge_inter
+        and state_of_charge_intra
+
+        According to:
+        L. Kotzur et al: 'Time series aggregation for energy system design:
+        Modeling seasonal storage', 2018
+        """
+
+        return(m.state_of_charge[s, h] ==
+               m.state_of_charge_intra[s, h] + m.state_of_charge_inter[
+                   s, network.cluster_ts['Candidate_day'][h]])
+
+    network.model.total_storage_constraint = po.Constraint(
+        sus.index, network.snapshots, rule=total_state_of_charge)
+
+    def state_of_charge_lower(m, s, h):
+        """
+        Define the state_of_charge as the sum of state_of_charge_inter
+        and state_of_charge_intra
+
+        According to:
+        L. Kotzur et al: 'Time series aggregation for energy system design:
+        Modeling seasonal storage', 2018
+        """
+
+      # Choose datetime of representive day
+        date = str(network.snapshots[
+            network.snapshots.dayofyear -1 ==
+            network.cluster['RepresentativeDay'][h.dayofyear]][0]).split(' ')[0]
+        hour = str(h).split(' ')[1]
+
+        intra_hour = pd.to_datetime(date + ' ' + hour)
+
+        return(m.state_of_charge_intra[s, intra_hour] +
+               m.state_of_charge_inter[s, network.cluster_ts['Candidate_day'][h]]
+               # * (1 - network.storage_units.at
+               # [s, 'standing_loss']*elapsed_hours)**24
+               >= 0)
+
+    network.model.state_of_charge_lower = po.Constraint(
+        sus.index, network.cluster_ts.index, rule=state_of_charge_lower)
+
+    network.model.del_component('state_of_charge_upper')
+    network.model.del_component('state_of_charge_upper_index')
+    network.model.del_component('state_of_charge_upper_index_0')
+    network.model.del_component('state_of_charge_upper_index_1')
+
+    def state_of_charge_upper(m, s, h):
+        date = str(network.snapshots[
+            network.snapshots.dayofyear -1 ==
+            network.cluster['RepresentativeDay'][h.dayofyear]][0]).split(' ')[0]
+
+        hour = str(h).split(' ')[1]
+
+        intra_hour = pd.to_datetime(date + ' ' + hour)
+
+        if network.storage_units.p_nom_extendable[s]:
+            p_nom = m.storage_p_nom[s]
+        else:
+            p_nom = network.storage_units.p_nom[s]
+
+        return (m.state_of_charge_intra[s, intra_hour] +
+                m.state_of_charge_inter[s, network.cluster_ts['Candidate_day'][h]]
+                # * (1 - network.storage_units.at[s,
+                # 'standing_loss']*elapsed_hours)**24
+                <= p_nom * network.storage_units.at[s, 'max_hours'])
+
+    network.model.state_of_charge_upper = po.Constraint(
+        sus.index, network.cluster_ts.index,
+        rule=state_of_charge_upper)
+
+    def cyclic_state_of_charge(m, s):
+        """
+        Defines cyclic condition like pypsas 'state_of_charge_contraint'.
+        There are small differences to original results.
+        """
+        last_day = network.cluster.index[-1]
+
+        last_calc_hour = network.cluster[
+            'last_hour_RepresentativeDay'][last_day]
+
+        last_inter = m.state_of_charge_inter[s, last_day]
+
+        last_intra = m.state_of_charge_intra[s, last_calc_hour]
+
+        first_day = network.cluster.index[0]
+
+        first_calc_hour = network.cluster[
+            'last_hour_RepresentativeDay'][first_day] - pd.DateOffset(hours=23)
+
+        first_inter = m.state_of_charge_inter[s, first_day]
+
+        first_intra = m.state_of_charge_intra[s, first_calc_hour]
+
+        return  (first_intra + first_inter == \
+               ((last_intra + last_inter)
+                * (1 - network.storage_units.at[s, 'standing_loss'])
+                -(m.storage_p_dispatch[s, last_calc_hour]/
+                  network.storage_units.at[s, 'efficiency_dispatch']
+                  -m.storage_p_store[s, last_calc_hour] *
+                  network.storage_units.at[s, 'efficiency_store'])))
+
+    network.model.cyclic_storage_constraint = po.Constraint(
+        sus.index, rule=cyclic_state_of_charge)
+
 class Constraints:
 
     def __init__(self, args):
@@ -971,227 +1198,23 @@ class Constraints:
 
 
         if self.args['snapshot_clustering']['active']:
-                # This will bound the storage level to 0.5 max_level every 24th hour.
-                sus = network.storage_units
-                # take every first hour of the clustered days
-                network.model.period_starts = \
-                    network.snapshot_weightings.index[0::24]
+            # This will bound the storage level to 0.5 max_level every 24th hour.
+            sus = network.storage_units
+            # take every first hour of the clustered days
+            network.model.period_starts = \
+                network.snapshot_weightings.index[0::24]
 
-                network.model.storages = sus.index
+            network.model.storages = sus.index
 
-                if self.args['snapshot_clustering']['storage_constraints'] \
-                    == 'daily_bounds':
+            if self.args['snapshot_clustering']['storage_constraints'] \
+                == 'daily_bounds':
 
-                    print('Setting daily_bounds constraint')
+                snapshot_clustering_daily_bounds(self, network, snapshots)
 
-                    def day_rule(m, s, p):
-                        """
-                        Sets the soc of the every first hour to the
-                        soc of the last hour of the day (i.e. + 23 hours)
-                        """
-                        return (m.state_of_charge[s, p] ==
-                                m.state_of_charge[s, p + pd.Timedelta(hours=23
-                                                                      )])
+            elif self.args['snapshot_clustering']['storage_constraints'] \
+                == 'soc_constraints':
+                    snapshot_clustering_seasonal_storage(self, network, snapshots)
 
-                    network.model.period_bound = Constraint(
-                        network.model.storages,
-                        network.model.period_starts, rule=day_rule)
-
-                elif self.args['snapshot_clustering']['storage_constraints'] \
-                    == 'soc_constraints':
-                    candidates = \
-                        network.cluster.index.get_level_values(0).unique()
-
-                    # create set for inter-temp constraints and variables
-                    network.model.candidates = po.Set(
-                        initialize=candidates, ordered=True)
-
-                    # create intra soc variable for each storage and each hour
-                    network.model.state_of_charge_intra = po.Var(
-                        sus.index, network.snapshots)
-
-                    def intra_soc_rule(m, s, h):
-                        """
-                        Sets soc_inter of first hour of every day to 0. Other hours
-                        are set by technical coherences of storage units
-
-                        According to:
-                        L. Kotzur et al: 'Time series aggregation for energy
-                        system design:
-                        Modeling seasonal storage', 2018, equation no. 18
-                        """
-
-                        if h.hour == 0:
-                            expr = (m.state_of_charge_intra[s, h] == 0)
-                        else:
-                            expr = (
-                                m.state_of_charge_intra[s, h] ==
-                                m.state_of_charge_intra[s, h-pd.DateOffset(hours=1)]
-                                * (1 - network.storage_units.at[s, 'standing_loss'])
-                                -(m.storage_p_dispatch[s, h-pd.DateOffset(hours=1)]/
-                                  network.storage_units.at[s, 'efficiency_dispatch'] -
-                                  network.storage_units.at[s, 'efficiency_store'] *
-                                  m.storage_p_store[s, h-pd.DateOffset(hours=1)]))
-                        return expr
-
-                    network.model.soc_intra = po.Constraint(
-                        network.model.storages, network.snapshots,
-                        rule=intra_soc_rule)
-
-                    # create inter soc variable for each storage and each candidate
-                    network.model.state_of_charge_inter = po.Var(
-                        sus.index, network.model.candidates,
-                        within=po.NonNegativeReals)
-
-                    def inter_storage_soc_rule(m, s, i):
-                        """
-                        Define the state_of_charge_inter as the state_of_charge_inter of
-                        the day before minus the storage losses plus the state_of_charge_intra
-                        of one hour after the last hour of the representative day.
-                        For the last reperesentive day, the soc_inter is the same as
-                        the first day due to cyclic soc condition
-
-                        According to:
-                        L. Kotzur et al: 'Time series aggregation for energy system design:
-                        Modeling seasonal storage', 2018, equation no. 19
-                        """
-
-                        if i == network.model.candidates[-1]:
-                            last_hour = network.cluster["last_hour_RepresentativeDay"][i]
-                            expr = po.Constraint.Skip
-
-                        else:
-                            last_hour = network.cluster["last_hour_RepresentativeDay"][i]
-                            expr = (
-                                m.state_of_charge_inter[s, i+1] ==
-                                m.state_of_charge_inter[s, i]
-                                * (1 - network.storage_units.at[s, 'standing_loss'])**24
-                                + m.state_of_charge_intra[s, last_hour]\
-                                    * (1 - network.storage_units.at[s, 'standing_loss'])\
-                                    -(m.storage_p_dispatch[s, last_hour]/\
-                                    network.storage_units.at[s, 'efficiency_dispatch'] -
-                                      network.storage_units.at[s, 'efficiency_store'] *
-                                      m.storage_p_store[s, last_hour]))
-
-                        return expr
-
-                    network.model.inter_storage_soc_constraint = po.Constraint(
-                        sus.index, network.model.candidates,
-                        rule=inter_storage_soc_rule)
-
-                    #new definition of the state_of_charge used in pypsa
-                    network.model.del_component('state_of_charge_constraint')
-                    network.model.del_component('state_of_charge_constraint_index')
-                    network.model.del_component('state_of_charge_constraint_index_0')
-                    network.model.del_component('state_of_charge_constraint_index_1')
-
-                    def total_state_of_charge(m, s, h):
-                        """
-                        Define the state_of_charge as the sum of state_of_charge_inter
-                        and state_of_charge_intra
-
-                        According to:
-                        L. Kotzur et al: 'Time series aggregation for energy system design:
-                        Modeling seasonal storage', 2018
-                        """
-
-                        return(m.state_of_charge[s, h] ==
-                               m.state_of_charge_intra[s, h] + m.state_of_charge_inter[
-                                   s, network.cluster_ts['Candidate_day'][h]])
-
-                    network.model.total_storage_constraint = po.Constraint(
-                        sus.index, network.snapshots, rule=total_state_of_charge)
-
-                    def state_of_charge_lower(m, s, h):
-                        """
-                        Define the state_of_charge as the sum of state_of_charge_inter
-                        and state_of_charge_intra
-
-                        According to:
-                        L. Kotzur et al: 'Time series aggregation for energy system design:
-                        Modeling seasonal storage', 2018
-                        """
-
-                      # Choose datetime of representive day
-                        date = str(network.snapshots[
-                            network.snapshots.dayofyear -1 ==
-                            network.cluster['RepresentativeDay'][h.dayofyear]][0]).split(' ')[0]
-                        hour = str(h).split(' ')[1]
-
-                        intra_hour = pd.to_datetime(date + ' ' + hour)
-
-                        return(m.state_of_charge_intra[s, intra_hour] +
-                               m.state_of_charge_inter[s, network.cluster_ts['Candidate_day'][h]]
-                               # * (1 - network.storage_units.at
-                               # [s, 'standing_loss']*elapsed_hours)**24
-                               >= 0)
-
-                    network.model.state_of_charge_lower = po.Constraint(
-                        sus.index, network.cluster_ts.index, rule=state_of_charge_lower)
-
-                    network.model.del_component('state_of_charge_upper')
-                    network.model.del_component('state_of_charge_upper_index')
-                    network.model.del_component('state_of_charge_upper_index_0')
-                    network.model.del_component('state_of_charge_upper_index_1')
-
-                    def state_of_charge_upper(m, s, h):
-                        date = str(network.snapshots[
-                            network.snapshots.dayofyear -1 ==
-                            network.cluster['RepresentativeDay'][h.dayofyear]][0]).split(' ')[0]
-
-                        hour = str(h).split(' ')[1]
-
-                        intra_hour = pd.to_datetime(date + ' ' + hour)
-
-                        if network.storage_units.p_nom_extendable[s]:
-                            p_nom = m.storage_p_nom[s]
-                        else:
-                            p_nom = network.storage_units.p_nom[s]
-
-                        return (m.state_of_charge_intra[s, intra_hour] +
-                                m.state_of_charge_inter[s, network.cluster_ts['Candidate_day'][h]]
-                                # * (1 - network.storage_units.at[s,
-                                # 'standing_loss']*elapsed_hours)**24
-                                <= p_nom * network.storage_units.at[s, 'max_hours'])
-
-                    network.model.state_of_charge_upper = po.Constraint(
-                        sus.index, network.cluster_ts.index,
-                        rule=state_of_charge_upper)
-
-                    def cyclic_state_of_charge(m, s):
-                        """
-                        Defines cyclic condition like pypsas 'state_of_charge_contraint'.
-                        There are small differences to original results.
-                        """
-                        last_day = network.cluster.index[-1]
-
-                        last_calc_hour = network.cluster[
-                            'last_hour_RepresentativeDay'][last_day]
-
-                        last_inter = m.state_of_charge_inter[s, last_day]
-
-                        last_intra = m.state_of_charge_intra[s, last_calc_hour]
-
-                        first_day = network.cluster.index[0]
-
-                        first_calc_hour = network.cluster[
-                            'last_hour_RepresentativeDay'][first_day] - pd.DateOffset(hours=23)
-
-                        first_inter = m.state_of_charge_inter[s, first_day]
-
-                        first_intra = m.state_of_charge_intra[s, first_calc_hour]
-
-                        return  (first_intra + first_inter == \
-                               ((last_intra + last_inter)
-                                * (1 - network.storage_units.at[s, 'standing_loss'])
-                                -(m.storage_p_dispatch[s, last_calc_hour]/
-                                  network.storage_units.at[s, 'efficiency_dispatch']
-                                  -m.storage_p_store[s, last_calc_hour] *
-                                  network.storage_units.at[s, 'efficiency_store'])))
-
-                    network.model.cyclic_storage_constraint = po.Constraint(
-                        sus.index, rule=cyclic_state_of_charge)
-
-                else:
-                    logger.error('snapshot clustering constraints must be in' +
-                                 ' [daily_bounds, soc_constraints]')
+            else:
+                logger.error('snapshot clustering constraints must be in' +
+                             ' [daily_bounds, soc_constraints]')

--- a/etrago/tools/utilities.py
+++ b/etrago/tools/utilities.py
@@ -1459,12 +1459,6 @@ def check_args(etrago):
             ("Number of selected days is smaller than number of "
              "representitive snapshots")
 
-        if not etrago.args['method']['pyomo']:
-            logger.warning("Snapshot clustering constraints are "
-                           "not yet implemented without pyomo. "
-                           "args['method']['pyomo'] is set to True.")
-            etrago.args['method']['pyomo'] = True
-
     if not etrago.args['method']['pyomo']:
         try:
             import gurobipy


### PR DESCRIPTION
This branch includes the snapshot clustering constraints without pyomo. It seems to work fine, but I only had a brief look at the results.
 @KathiEsterl Could you maybe check more in detailed if it works as expected? I can explain you how you can extract the values for `soc_intra` from the results. 