### PR TITLE
Update pypsa version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
                       'shapely',
                       'oedialect',
                       'tilemapbase == 0.4.5',
-                      'pypsa == 0.17.1',
+                      'pypsa == 0.19.1',
                       'setuptools >= 54.2.0',
                       'geopandas',
                       'rtree'],


### PR DESCRIPTION
Closes #369 
Closes #373 
The checks were easier than expected, `pypsa` is now compatible to other newer package versions (e.g. `pandas>1.4`) but it is not required to use the updated versions. 