### PR TITLE
Add option to use stored ch4-busmap for gas_clustering

### DIFF
--- a/etrago/appl.py
+++ b/etrago/appl.py
@@ -78,6 +78,7 @@ args = {
         'n_clusters': 50, # number of resulting nodes
         'n_clusters_gas': 10, # number of resulting nodes in Germany
         'kmeans_busmap': False, # False or path/to/busmap.csv
+        'kmeans_gas_busmap': False, # False or path/to/ch4_busmap.csv
         'line_length_factor': 1, #
         'remove_stubs': False, # remove stubs bevore kmeans clustering
         'use_reduced_coordinates': False, #
@@ -334,7 +335,6 @@ def run_etrago(args, json_path):
     # import network from database
     etrago.build_network_from_db()
 
-    
     etrago.network.lines.type = ''
     etrago.network.lines.carrier.fillna('AC', inplace=True)
     etrago.network.buses.v_mag_pu_set.fillna(1., inplace=True)

--- a/etrago/cluster/gasclustering.py
+++ b/etrago/cluster/gasclustering.py
@@ -77,14 +77,28 @@ def create_gas_busmap(etrago):
     weight_ch4_s = weight_ch4.squeeze()
 
     # Creation of the busmap
-    busmap_ch4 = busmap_by_kmeans(
+
+    if not kmean_gas_settings["kmeans_gas_busmap"]:
+        
+        busmap_ch4 = busmap_by_kmeans(
         network_ch4,
         bus_weightings=weight_ch4_s,
         n_clusters=kmean_gas_settings["n_clusters_gas"],
         n_init=kmean_gas_settings["n_init"],
         max_iter=kmean_gas_settings["max_iter"],
         tol=kmean_gas_settings["tol"],
-    )
+        )
+        
+        busmap_ch4.to_csv(
+            "kmeans_ch4_busmap_" + str(kmean_gas_settings["n_clusters_gas"]) + "_result.csv"
+        )
+   
+    else:
+        
+        df = pd.read_csv(kmean_gas_settings["kmeans_gas_busmap"])
+        df = df.astype(str)
+        df = df.set_index("Bus")
+        busmap_ch4 = df.squeeze("columns")
 
     # Add H2_grid buses to busmap
     df_correspondance_H2_CH4 = etrago.network.links[


### PR DESCRIPTION
I added the functionality of using a given ch4-busmap for the gas_clustering to be able to reproduce the exact same network in different calculation runs. 

@AmeliaNadal , what do you think of this approach? Are you okay with this or do you have a better idea to tackle this?