### PR TITLE
Features/#371 update capital cost

### DIFF
--- a/etrago/tools/extendable.py
+++ b/etrago/tools/extendable.py
@@ -103,8 +103,6 @@ def extendable(self, line_max):
             else:
                 network.links.p_nom_max = float("inf")
 
-        network = self.set_line_costs()
-        network = self.set_trafo_costs()
 
     if 'german_network' in self.args['extendable']:
         buses = network.buses[~network.buses.index.isin(
@@ -166,8 +164,6 @@ def extendable(self, line_max):
                     (network.links.bus1.isin(buses.index)),
                     'p_nom_max'] = float("inf")
 
-        network = set_line_costs(network)
-        network = set_trafo_costs(network)
 
     if 'foreign_network' in self.args['extendable']:
         buses = network.buses[network.buses.index.isin(
@@ -228,14 +224,13 @@ def extendable(self, line_max):
                     (network.links.bus1.isin(buses.index)),
                     'p_nom_max'] = float("inf")
 
-        network = set_line_costs(network)
-        network = set_trafo_costs(network)
+
 
     if 'transformers' in self.args['extendable']:
         network.transformers.s_nom_extendable = True
         network.transformers.s_nom_min = network.transformers.s_nom
         network.transformers.s_nom_max = float("inf")
-        network = set_trafo_costs(network)
+
 
     if 'storages' in self.args['extendable'] or 'storage' in self.args['extendable']:
         if not network.storage_units.carrier[
@@ -315,19 +310,6 @@ def extendable(self, line_max):
                 'extension_' + self.args['scn_extension'][i]
             ), 'capital_cost'] = network.lines.capital_cost
 
-    network.lines.s_nom_min[network.lines.s_nom_extendable == False] =\
-        network.lines.s_nom
-
-    network.transformers.s_nom_min[network.transformers.s_nom_extendable == \
-        False] = network.transformers.s_nom
-
-    network.lines.s_nom_max[network.lines.s_nom_extendable == False] =\
-        network.lines.s_nom
-
-    network.transformers.s_nom_max[network.transformers.s_nom_extendable == \
-        False] = network.transformers.s_nom
-
-    self.convert_capital_costs()
 
     return network
 
@@ -386,8 +368,7 @@ def extension_preselection(etrago, method, days=3):
     network.transformers.loc[:, 's_nom_min'] = network.transformers.s_nom
     network.transformers.loc[:, 's_nom_max'] = np.inf
 
-    network = set_line_costs(network)
-    network = set_trafo_costs(network)
+
     network = convert_capital_costs(network, 1, 1)
     extended_lines = network.lines.index[network.lines.s_nom_opt >
                                          network.lines.s_nom]
@@ -424,8 +405,6 @@ def extension_preselection(etrago, method, days=3):
         = np.inf
 
     network.snapshot_weightings = weighting
-    network = set_line_costs(network)
-    network = set_trafo_costs(network)
     network = convert_capital_costs(network, args['start_snapshot'],
                                     args['end_snapshot'])
 

--- a/etrago/tools/network.py
+++ b/etrago/tools/network.py
@@ -261,6 +261,8 @@ class Etrago():
 
         self.extendable(line_max=4)
 
+        self.convert_capital_costs()
+
     def _ts_weighted(self, timeseries):
         return timeseries.mul(self.network.snapshot_weightings, axis=0)
 

--- a/etrago/tools/utilities.py
+++ b/etrago/tools/utilities.py
@@ -1089,15 +1089,13 @@ def add_missing_components(self):
     return network
 
 
-def convert_capital_costs(self, p=0.05, T=40):
-    """Convert capital_costs to fit to pypsa and caluculated time
+def convert_capital_costs(self):
+    """Convert capital_costs to fit to considered timesteps
 
     Parameters
     ----------
     etrago : :class:`etrago.Etrago
         Transmission grid object
-    p : interest rate, default 0.05
-    T : number of periods, default 40 years (source: StromNEV Anlage 1)
     -------
 
     """
@@ -1105,29 +1103,29 @@ def convert_capital_costs(self, p=0.05, T=40):
     network = self.network
     n_snapshots = self.args["end_snapshot"] - self.args["start_snapshot"] + 1
 
-    # Add costs for DC-converter
-    network.links.loc[self.dc_lines().index, "capital_cost"] += 400000
+    # Costs are already annuized yearly in the datamodel
+    # adjust to number of considered snapshots
 
-    # Calculate present value of an annuity (PVA)
-    PVA = (1 / p) - (1 / (p * (1 + p) ** T))
+    network.lines.loc[
+        network.lines.s_nom_extendable == True, "capital_cost"
+        ] *= 8760 / n_snapshots
 
-    # Apply function on lines, links, trafos and storages
-    # Storage costs are already annuized yearly
-    network.lines.loc[network.lines.s_nom_extendable == True, "capital_cost"] /= PVA * (
-        8760 / n_snapshots
-    )
-
-    network.links.loc[network.links.p_nom_extendable == True, "capital_cost"] /= PVA * (
-        8760 / n_snapshots
-    )
+    network.links.loc[
+        network.links.p_nom_extendable == True, "capital_cost"
+        ] *= 8760 / n_snapshots
 
     network.transformers.loc[
         network.transformers.s_nom_extendable == True, "capital_cost"
-    ] /= PVA * (8760 / n_snapshots)
+    ] *= 8760 / n_snapshots
 
     network.storage_units.loc[
         network.storage_units.p_nom_extendable == True, "capital_cost"
-    ] /= PVA * (8760 / n_snapshots)
+    ] *=  (8760 / n_snapshots)
+
+    network.stores.loc[
+        network.stores.e_nom_extendable == True, "capital_cost"
+    ] *=  (8760 / n_snapshots)
+
 
 
 def find_snapshots(network, carrier, maximum=True, minimum=True, n=3):


### PR DESCRIPTION
Closes #371 
This branch avoids overwriting of capital costs from the data model. 
The capital_costs are already annualized in eGon-data. `convert_capital_costs`function  is now used to calculate intra-year investment costs according to the number of selected snapshots. 
I tested this branch with a new data model for Schleswig-Holstein.