### PR TITLE
Update single carrier based sector coupling clustering strategy

### DIFF
--- a/etrago/appl.py
+++ b/etrago/appl.py
@@ -90,14 +90,17 @@ args = {
     'sector_coupled_clustering': {
         'active': True, # choose if clustering is activated
         'carrier_data': { # select carriers affected by sector coupling
-            'H2_ind_load': {
-                'base': ['H2_grid'],
-            },
-            'central_heat': {
-                'base': ['CH4'],
-            },
+            # 'H2_ind_load': {
+            #     'base': ['H2_grid'],
+            #     'strategy': 'consecutive'
+            # },
+            # 'central_heat': {
+            #     'base': ['CH4', 'AC'],
+            #     'strategy': 'consecutive'
+            # },
             'rural_heat': {
-                'base': ['CH4'],
+                'base': ['CH4', 'AC'],
+                'strategy': 'consecutive'
             },
         },
     },
@@ -402,7 +405,7 @@ def run_etrago(args, json_path):
         etrago.network.generators.carrier=='CH4']+= 25.6+0.201*76.5
 
     # ehv network clustering
-    etrago.ehv_clustering()
+    # etrago.ehv_clustering()
 
     # k-mean clustering
     etrago.kmean_clustering()

--- a/etrago/appl.py
+++ b/etrago/appl.py
@@ -90,14 +90,14 @@ args = {
     'sector_coupled_clustering': {
         'active': True, # choose if clustering is activated
         'carrier_data': { # select carriers affected by sector coupling
-            # 'H2_ind_load': {
-            #     'base': ['H2_grid'],
-            #     'strategy': 'consecutive'
-            # },
-            # 'central_heat': {
-            #     'base': ['CH4', 'AC'],
-            #     'strategy': 'consecutive'
-            # },
+            'H2_ind_load': {
+                'base': ['H2_grid'],
+                'strategy': 'consecutive'
+            },
+            'central_heat': {
+                'base': ['CH4', 'AC'],
+                'strategy': 'consecutive'
+            },
             'rural_heat': {
                 'base': ['CH4', 'AC'],
                 'strategy': 'consecutive'

--- a/etrago/appl.py
+++ b/etrago/appl.py
@@ -408,7 +408,7 @@ def run_etrago(args, json_path):
         etrago.network.generators.carrier=='CH4']+= 25.6+0.201*76.5
 
     # ehv network clustering
-    # etrago.ehv_clustering()
+    etrago.ehv_clustering()
 
     # k-mean clustering
     etrago.kmean_clustering()

--- a/etrago/cluster/gasclustering.py
+++ b/etrago/cluster/gasclustering.py
@@ -156,10 +156,10 @@ def create_gas_busmap(etrago):
                 busmap_sector_coupling = consecutive_sector_coupling(
                     etrago.network, busmap, data["base"], name,
                 )
-            elif strategy == "simultanous":
+            elif strategy == "simultaneous":
                 if len(data["base"]) < 2:
                     msg = (
-                        "To apply simultanous clustering for the " + name +
+                        "To apply simultaneous clustering for the " + name +
                         " buses, at least 2 base buses must be selected."
                     )
                     raise ValueError(msg)
@@ -362,10 +362,10 @@ def consecutive_sector_coupling(network, busmap, carrier_based, carrier_to_clust
     ]
 
     # map skipped buses after clustering
-    skipped_links["bus0_clustered"] = skipped_links["bus0"].map(busmap).fillna(skipped_links["bus0"])
-    skipped_links["bus1_clustered"] = skipped_links["bus1"].map(busmap).fillna(skipped_links["bus1"])
+    skipped_links["bus0_clustered"] = skipped_links["bus0"].map(busmap_sc).fillna(skipped_links["bus0"])
+    skipped_links["bus1_clustered"] = skipped_links["bus1"].map(busmap_sc).fillna(skipped_links["bus1"])
 
-    busmap_series = pd.Series(busmap)
+    busmap_series = pd.Series(busmap_sc)
     next_bus_id = highestInteger(busmap_series.values) + 1
 
     # create clusters for skipped buses
@@ -373,12 +373,12 @@ def consecutive_sector_coupling(network, busmap, carrier_based, carrier_to_clust
     for i in range(len(clusters)):
         buses = skipped_links.loc[skipped_links["bus0_clustered"] == clusters[i], "bus1_clustered"]
         for bus_id in buses:
-            busmap[bus_id] = next_bus_id + i
+            busmap_sc[bus_id] = next_bus_id + i
         buses = skipped_links.loc[skipped_links["bus1_clustered"] == clusters[i], "bus0_clustered"]
         for bus_id in buses:
-            busmap[bus_id] = next_bus_id + i
+            busmap_sc[bus_id] = next_bus_id + i
 
-    return busmap
+    return busmap_sc
 
 
 def sc_multi_carrier_based(buses_to_cluster, connected_links):

--- a/etrago/cluster/gasclustering.py
+++ b/etrago/cluster/gasclustering.py
@@ -324,6 +324,7 @@ def consecutive_sector_coupling(network, busmap, carrier_based, carrier_to_clust
 
         # remove already clustered buses
         buses_to_cluster = buses_to_cluster[~buses_to_cluster.index.isin(busmap_sc.keys())]
+        buses_clustered = network.buses[network.buses["carrier"] == base]
 
         connected_links = network.links.loc[
             network.links["bus0"].isin(buses_clustered.index)

--- a/etrago/cluster/gasclustering.py
+++ b/etrago/cluster/gasclustering.py
@@ -343,10 +343,17 @@ def consecutive_sector_coupling(network, busmap, carrier_based, carrier_to_clust
             busmap_by_base[bus_id] = bus_num + next_bus_id
 
         next_bus_id = bus_num + next_bus_id
-
         busmap_sc.update(busmap_by_base)
 
-        breakpoint()
+
+    buses_to_cluster = buses_to_cluster[~buses_to_cluster.index.isin(busmap_sc.keys())]
+
+    if len(buses_to_cluster) > 0:
+        msg = (
+            "The following buses are not added to any cluster: " +
+            buses_to_cluster.index.to_string()
+        )
+        logger.warning(msg)
 
     # cluster appedices
     skipped_links = network.links.loc[

--- a/etrago/cluster/gasclustering.py
+++ b/etrago/cluster/gasclustering.py
@@ -342,7 +342,7 @@ def consecutive_sector_coupling(network, busmap, carrier_based, carrier_to_clust
 
             busmap_by_base[bus_id] = bus_num + next_bus_id
 
-        next_bus_id = bus_num + next_bus_id
+        next_bus_id = bus_num + next_bus_id + 1
         busmap_sc.update(busmap_by_base)
 
 

--- a/etrago/cluster/gasclustering.py
+++ b/etrago/cluster/gasclustering.py
@@ -285,8 +285,6 @@ def simultaneous_sector_coupling(network, busmap, carrier_based, carrier_to_clus
         for bus_id in buses:
             busmap[bus_id] = next_bus_id + i
 
-    breakpoint()
-
     return busmap
 
 
@@ -345,13 +343,12 @@ def consecutive_sector_coupling(network, busmap, carrier_based, carrier_to_clust
         next_bus_id = bus_num + next_bus_id + 1
         busmap_sc.update(busmap_by_base)
 
-
     buses_to_cluster = buses_to_cluster[~buses_to_cluster.index.isin(busmap_sc.keys())]
 
     if len(buses_to_cluster) > 0:
         msg = (
             "The following buses are not added to any cluster: " +
-            buses_to_cluster.index.to_string()
+            str(buses_to_cluster.index)
         )
         logger.warning(msg)
 

--- a/etrago/cluster/gasclustering.py
+++ b/etrago/cluster/gasclustering.py
@@ -46,7 +46,7 @@ def create_gas_busmap(etrago):
 
     num_neighboring_country = (
         (network_ch4.buses["carrier"] == "CH4")
-        & (network_ch4.buses["country"] == "DE")
+        & (network_ch4.buses["country"] != "DE")
     ).sum()
 
     # Cluster ch4 buses


### PR DESCRIPTION
Resolve #399 

At the example of rural heat, the strategy implemented here does the following:

- cluster the rural heat buses based on the CH4 grid
- cluster the rural heat buses without connection to CH4 grid around AC grid
- throw a warning message, if rural heat buses have no connection to either CH4 and AC

We still need to discuss, what to do with the remaining buses:
- Are those errors in the data model?
- Are those separated/autarc systems, which can be put in a single separate cluster, for example?
- ...

The order of carriers provided in the `base` keyword dictates the order of clustering. Be selecting `'consecutive'` as strategy, this approach is performed. The multi carrier based approach is still implemented, for this, the `'simultanous'` strategy has to be chosen.