### PR TITLE
Fix capital cost update

### DIFF
--- a/etrago/tools/utilities.py
+++ b/etrago/tools/utilities.py
@@ -1108,23 +1108,23 @@ def convert_capital_costs(self):
 
     network.lines.loc[
         network.lines.s_nom_extendable == True, "capital_cost"
-        ] *= 8760 / n_snapshots
+        ] *= n_snapshots / 8760
 
     network.links.loc[
         network.links.p_nom_extendable == True, "capital_cost"
-        ] *= 8760 / n_snapshots
+        ] *= n_snapshots / 8760
 
     network.transformers.loc[
         network.transformers.s_nom_extendable == True, "capital_cost"
-    ] *= 8760 / n_snapshots
+    ] *= n_snapshots / 8760
 
     network.storage_units.loc[
         network.storage_units.p_nom_extendable == True, "capital_cost"
-    ] *=  (8760 / n_snapshots)
+    ] *=  n_snapshots / 8760
 
     network.stores.loc[
         network.stores.e_nom_extendable == True, "capital_cost"
-    ] *=  (8760 / n_snapshots)
+    ] *=  n_snapshots / 8760
 
 
 


### PR DESCRIPTION
Capital costs should be smaller when not all snapshots are considered. I did a mistake in the previous implementation, sorry!