### PR TITLE
Feature/update n clusters gas

### DIFF
--- a/etrago/appl.py
+++ b/etrago/appl.py
@@ -93,12 +93,10 @@ args = {
     # Clustering:
     "network_clustering_kmeans": {
         "active": True,  # choose if clustering is activated
-        'n_clusters': 30, # number of resulting nodes in specified region (only DE or DE+foreign)
-        'cluster_foreign_AC': False, # take foreign AC buses into account, True or False
-        "cluster_foreign_gas": False,  # cluster foreign gas buses, True or False
-        "n_clusters_gas": 30,  # number of resulting nodes in specified region (only DE or DE+foreign);
-        # Note: Number of resulting nodes depends on if foreign nodes are clustered.
-        # If not, total number of nodes is n_clusters_gas + foreign_buses (usually 13)
+        "n_clusters": 30,  # total number of resulting AC nodes (DE+foreign)
+        "cluster_foreign_AC": False,  # take foreign AC buses into account, True or False
+        "cluster_foreign_gas": False,  # take foreign CH4 buses into account, True or False
+        "n_clusters_gas": 30,  # total number of resulting CH4 nodes (DE+foreign)
         "kmeans_busmap": False,  # False or path/to/busmap.csv
         "kmeans_gas_busmap": False,  # False or path/to/ch4_busmap.csv
         "line_length_factor": 1,  #
@@ -325,7 +323,7 @@ def run_etrago(args, json_path):
                 by carrier, set upper/lower limit in p.u.
 
     network_clustering_kmeans : dict
-          {'active': True, 'n_clusters': 30, 'cluster_foreign_AC': False,
+          {'active': True, 'n_clusters': 30, 'cluster_foreign_AC': False, 'cluster_foreign_gas': False,
            'n_clusters_gas': 30, 'kmeans_busmap': False, 'line_length_factor': 1.25,
            'remove_stubs': False, 'use_reduced_coordinates': False,
            'bus_weight_tocsv': None, 'bus_weight_fromcsv': None,
@@ -339,9 +337,6 @@ def run_etrago(args, json_path):
         The weighting takes place considering generation and load at each node.
         ``'cluster_foreign_gas'`` controls whether gas buses of Germanies
         neighboring countries are considered for clustering.
-        Note, that this option influences the total
-        resulting number of nodes (``'n_clusters_gas'`` if ``'cluster_foreign_gas'``)
-        is True or (``'n_clusters_gas'`` + number of neighboring countries) otherwise.
         With ``'kmeans_busmap'`` you can choose if you want to load cluster
         coordinates from a previous run.
         Option ``'remove_stubs'`` reduces the overestimating of line meshes.

--- a/etrago/cluster/gasclustering.py
+++ b/etrago/cluster/gasclustering.py
@@ -48,6 +48,10 @@ def create_gas_busmap(etrago):
     # Cluster ch4 buses
     kmean_gas_settings = etrago.args["network_clustering_kmeans"]
 
+    num_neighboring_country = (
+        (network_ch4.buses["carrier"] == "CH4") & (network_ch4.buses["country"] != "DE")
+    ).sum()
+
     # select buses dependent on whether they should be clustered in (only DE or DE+foreign)
     if kmean_gas_settings["cluster_foreign_gas"] == False:
 
@@ -55,6 +59,16 @@ def create_gas_busmap(etrago):
             (network_ch4.buses["carrier"] == "CH4")
             & (network_ch4.buses["country"] == "DE")
         ]
+
+        if kmean_gas_settings["n_clusters_gas"] <= num_neighboring_country:
+            msg = (
+                "The number of clusters for the gas sector ("
+                + str(kmean_gas_settings["n_clusters_gas"])
+                + ") must be higher than the number of neighboring country gas buses ("
+                + str(num_neighboring_country)
+                + ")."
+            )
+            raise ValueError(msg)
 
     else:
         network_ch4.buses = network_ch4.buses[network_ch4.buses["carrier"] == "CH4"]
@@ -154,7 +168,8 @@ def create_gas_busmap(etrago):
         busmap_ch4 = busmap_by_kmeans(
             network_ch4,
             bus_weightings=weight_ch4_s,
-            n_clusters=kmean_gas_settings["n_clusters_gas"],
+            n_clusters=kmean_gas_settings["n_clusters_gas"]
+            - num_neighboring_country * (not kmean_gas_settings["cluster_foreign_gas"]),
             n_init=kmean_gas_settings["n_init"],
             max_iter=kmean_gas_settings["max_iter"],
             tol=kmean_gas_settings["tol"],
@@ -683,9 +698,7 @@ def kmean_clustering_gas_grid(etrago):
     cluster_foreign_gas : bool
         Controls if foreign gas nodes are considered for clustering
     n_clusters_gas : int
-        Desired number of gas clusters. Note: The final number of gas clusters depends
-        on whether non-DE nodes are considered for clustering. If not, the total
-        number of resulting nodes is n_clusters_gas + foreign_buses (usually 13)
+        Desired total number of gas clusters (DE+foreign).
     gas_weight_tocsv : str
         Creates a CH4-bus weighting based on connected CH4-loads,
         CH4-generators and non-transport link capacities and save it to a csv file.


### PR DESCRIPTION
Updated and tested everything according to our discussion: n_clusters_gas now refers to the total number of resulting buses regardless of wether foreign nodes are considered or not.