### PR TITLE
Refer to correct db specification

### DIFF
--- a/etrago/tools/network.py
+++ b/etrago/tools/network.py
@@ -123,7 +123,7 @@ class Etrago():
 
             self.get_args_setting(json_path)
 
-            conn = db.connection(section=args['db'])
+            conn = db.connection(section=self.args['db'])
 
             session = sessionmaker(bind=conn)
 


### PR DESCRIPTION
Fix https://github.com/openego/eTraGo/issues/457

The `etrago.args` attribute is overwritten in line 124 of etrago/tools/network.py but the database selection refers to the default args.