### PR TITLE
Fix datatype for links_t attribute of network

### DIFF
--- a/etrago/cluster/networkclustering.py
+++ b/etrago/cluster/networkclustering.py
@@ -381,6 +381,8 @@ def group_links(network, with_time=True, carriers=None, cus_strateg=dict()):
             else:
                 new_pnl[attr] = network.links_t[attr]
 
+    new_pnl = pypsa.descriptors.Dict(new_pnl)
+
     return new_df, new_pnl
 
 


### PR DESCRIPTION
Resolve #471 

@CarlosEpia & @pieterhexen: Could you check, whether this works for you? I did not actually run a lopf, but just before the lopf the datatype for the links_t seems to be correct now.

Thank you!