### PR TITLE
Replace NaN values with pypsa's default values during import

### DIFF
--- a/etrago/appl.py
+++ b/etrago/appl.py
@@ -425,33 +425,8 @@ def run_etrago(args, json_path):
 
     # import network from database
     etrago.build_network_from_db()
-    etrago.network.lines.type = ""
-    etrago.network.lines.carrier.fillna("AC", inplace=True)
-    etrago.network.buses.v_mag_pu_set.fillna(1.0, inplace=True)
-    etrago.network.loads.sign = -1
-    etrago.network.links.capital_cost.fillna(0, inplace=True)
-    etrago.network.links.p_nom_min.fillna(0, inplace=True)
-    etrago.network.transformers.tap_ratio.fillna(1.0, inplace=True)
-    etrago.network.stores.e_nom_max.fillna(np.inf, inplace=True)
-    etrago.network.links.p_nom_max.fillna(np.inf, inplace=True)
-    etrago.network.links.efficiency.fillna(1.0, inplace=True)
-    etrago.network.links.marginal_cost.fillna(0.0, inplace=True)
-    etrago.network.links.p_min_pu.fillna(0.0, inplace=True)
-    etrago.network.links.p_max_pu.fillna(1.0, inplace=True)
-    etrago.network.links.p_nom.fillna(0.1, inplace=True)
-    etrago.network.storage_units.p_nom.fillna(0, inplace=True)
-    etrago.network.stores.e_nom.fillna(0, inplace=True)
-    etrago.network.stores.capital_cost.fillna(0, inplace=True)
-    etrago.network.stores.e_nom_max.fillna(np.inf, inplace=True)
-    etrago.network.storage_units.efficiency_dispatch.fillna(1.0, inplace=True)
-    etrago.network.storage_units.efficiency_store.fillna(1.0, inplace=True)
-    etrago.network.storage_units.capital_cost.fillna(0.0, inplace=True)
-    etrago.network.storage_units.p_nom_max.fillna(np.inf, inplace=True)
-    etrago.network.storage_units.standing_loss.fillna(0.0, inplace=True)
+
     etrago.network.storage_units.lifetime = np.inf
-    etrago.network.lines.v_ang_min.fillna(0.0, inplace=True)
-    etrago.network.links.terrain_factor.fillna(1.0, inplace=True)
-    etrago.network.lines.v_ang_max.fillna(1.0, inplace=True)
     etrago.network.transformers.lifetime = 40  # only temporal fix
     etrago.network.lines.lifetime = 40  # only temporal fix until either the
     # PyPSA network clustering function
@@ -459,13 +434,10 @@ def run_etrago(args, json_path):
     # data model is altered, which will
     # happen in the next data creation run
 
-    for t in etrago.network.iterate_components():
-        if "p_nom_max" in t.df:
-            t.df["p_nom_max"].fillna(np.inf, inplace=True)
-
-    for t in etrago.network.iterate_components():
-        if "p_nom_min" in t.df:
-            t.df["p_nom_min"].fillna(0.0, inplace=True)
+    etrago.network.lines_t.s_max_pu = (
+        etrago.network.lines_t.s_max_pu.transpose()
+        [etrago.network.lines_t.s_max_pu.columns.isin(
+            etrago.network.lines.index)].transpose())
 
     etrago.adjust_network()
 

--- a/etrago/cluster/networkclustering.py
+++ b/etrago/cluster/networkclustering.py
@@ -368,7 +368,7 @@ def group_links(network, with_time=True, carriers=None, cus_strateg=dict()):
     if with_time:
         for attr, df in network.links_t.items():
             pnl_links_agg_b = df.columns.to_series().map(links_agg_b)
-            df_agg = df.loc[:, pnl_links_agg_b]
+            df_agg = df.loc[:, pnl_links_agg_b].astype(float)
             if not df_agg.empty:
                 if attr in ["efficiency", "p_max_pu", "p_min_pu"]:
                     df_agg = df_agg.multiply(weighting.loc[df_agg.columns], axis=1)

--- a/etrago/tools/io.py
+++ b/etrago/tools/io.py
@@ -302,6 +302,9 @@ class NetworkScenario(ScenarioBase):
 
                 df.index = self.timeindex
 
+                df.fillna(network.component_attrs[pypsa_name].default[col],
+                             inplace=True)
+
                 pypsa.io.import_series_from_dataframe(
                                 network,
                                 df,
@@ -334,6 +337,13 @@ class NetworkScenario(ScenarioBase):
 
             # Drop columns with only NaN values
             df = df.drop(df.isnull().all()[df.isnull().all()].index, axis=1)
+
+            # Replace NaN values with defailt values from pypsa
+            for c in df.columns:
+                if c in network.component_attrs[pypsa_comp].index:
+                    df[c].fillna(network.component_attrs[pypsa_comp].default[c],
+                                 inplace=True)
+
             if pypsa_comp == 'Generator':
                 df.sign=1
 

--- a/etrago/tools/io.py
+++ b/etrago/tools/io.py
@@ -298,12 +298,13 @@ class NetworkScenario(ScenarioBase):
 
             if not df_all.isnull().all().all():
 
+                if col in network.component_attrs[pypsa_name].index:
+                    df_all.fillna(network.component_attrs[pypsa_name].default[col],
+                                 inplace=True)
+
                 df = df_all.anon_1.apply(pd.Series).transpose()
 
                 df.index = self.timeindex
-
-                df.fillna(network.component_attrs[pypsa_name].default[col],
-                             inplace=True)
 
                 pypsa.io.import_series_from_dataframe(
                                 network,


### PR DESCRIPTION
This branch replaces all NaN-values with the default values directly in the import of the network. This way, we can avoid setting these values manually in the application file.