### PR TITLE
Import s_max_pu time series of lines in gas clustering

### DIFF
--- a/etrago/cluster/gas.py
+++ b/etrago/cluster/gas.py
@@ -367,6 +367,12 @@ def gas_postprocessing(etrago, busmap, medoid_idx):
 
     # Insert components not related to the gas clustering
     io.import_components_from_dataframe(network_gasgrid_c, etrago.network.lines, "Line")
+    io.import_series_from_dataframe(
+        network_gasgrid_c,
+        etrago.network.lines_t.s_max_pu,
+        "Line",
+        "s_max_pu")
+    
     io.import_components_from_dataframe(
         network_gasgrid_c, etrago.network.storage_units, "StorageUnit"
     )


### PR DESCRIPTION
Hi @AmeliaNadal and @pieterhexen 
This change seems to fix #542, could you have a look if it makes sense? 
I only added the s_max_pu timeseries of lines, we don't use time series of storage_units or transformers (yet), but if we would do so, they would be also deleted in that function. So it might be a good idea to automatically add al time series data of these components. 