### PR TITLE
Fix p_nom_max agrregation with inf values

### DIFF
--- a/etrago/cluster/gas.py
+++ b/etrago/cluster/gas.py
@@ -19,7 +19,7 @@ if "READTHEDOCS" not in os.environ:
     from six import iteritems
 
     from etrago.cluster.spatial import (
-        agg_e_nom_max,
+        sum_with_inf,
         group_links,
         kmedoids_dijkstra_clustering,
     )
@@ -330,7 +330,7 @@ def gas_postprocessing(etrago, busmap, medoid_idx):
                 "marginal_cost": np.mean,
                 "capital_cost": np.mean,
                 "e_nom": np.sum,
-                "e_nom_max": agg_e_nom_max,
+                "e_nom_max": sum_with_inf,
             },
             "Load": {
                 "p_set": np.sum,

--- a/etrago/cluster/spatial.py
+++ b/etrago/cluster/spatial.py
@@ -74,6 +74,12 @@ def ext_storage(x):
     return v
 
 
+def sum_with_inf(x):
+    if (x == np.inf).any():
+        return np.inf
+    else:
+        return x.sum()
+
 def strategies_one_ports():
     return {
         "StorageUnit": {
@@ -91,27 +97,22 @@ def strategies_one_ports():
             "standing_loss": np.mean,
             "e_nom": np.sum,
             "e_nom_min": np.sum,
-            "e_nom_max": np.sum,
+            "e_nom_max": sum_with_inf,
             "e_initial": np.sum,
         },
     }
 
-def agg_e_nom_max(x):
-    if (x == np.inf).any():
-        return np.inf
-    else:
-        return x.sum()
 
 def strategies_generators():
     return {
         "p_nom_min": np.min,
-        "p_nom_max": np.min,
+        "p_nom_max": sum_with_inf,
         "weight": np.sum,
         "p_nom": np.sum,
         "p_nom_opt": np.sum,
         "marginal_cost": np.mean,
         "capital_cost": np.mean,
-        "e_nom_max": agg_e_nom_max,
+        "e_nom_max": sum_with_inf,
     }
 
 def strategies_links():
@@ -122,7 +123,7 @@ def strategies_links():
         "carrier": _make_consense_links,
         "p_nom": np.sum,
         "p_nom_extendable": _make_consense_links,
-        "p_nom_max": np.sum,
+        "p_nom_max": sum_with_inf,
         "capital_cost": np.mean,
         "length": np.mean,
         "geom": nan_links,


### PR DESCRIPTION
Fixes #548 
With this fix, the aggregation of np.inf values returns np.inf again instead of NaN. 

I'm sorry for the amount of PR I created in the last days... But could someone of you have a look at it @KathiEsterl, @AmeliaNadal or @pieterhexen ? Thank you in advance!