### PR TITLE
fixed geom of new lines when buses are removed in adjust_network()

### DIFF
--- a/etrago/tools/utilities.py
+++ b/etrago/tools/utilities.py
@@ -35,7 +35,7 @@ import pandas as pd
 import pypsa
 from egoio.tools import db
 from pyomo.environ import Constraint, PositiveReals, Var
-from shapely.geometry import Point
+from shapely.geometry import Point, LineString
 
 logger = logging.getLogger(__name__)
 
@@ -1071,6 +1071,18 @@ def delete_dispensable_ac_buses(etrago):
         l_new = agg_series_lines(lines_group, network)
         l_new["bus0"] = new_lines.at[l, "bus0"]
         l_new["bus1"] = new_lines.at[l, "bus1"]
+        l_new["geom"] = LineString(
+            [
+                (
+                    network.buses.at[l_new["bus0"], "x"],
+                    network.buses.at[l_new["bus0"], "y"],
+                ),
+                (
+                    network.buses.at[l_new["bus1"], "x"],
+                    network.buses.at[l_new["bus1"], "y"],
+                ),
+            ]
+        )
         new_lines_df["s_nom_extendable"] = new_lines_df["s_nom_extendable"].astype(bool)
         new_lines_df.loc[l_new.name] = l_new
 


### PR DESCRIPTION
Added new geom LineString Data from bus0 to bus1 for new links. Here is a little impression from result in QGIS:
<img width="474" alt="geom" src="https://user-images.githubusercontent.com/78430450/206207149-65116903-aacb-4d6f-a6f0-fd0aa3e3ba79.png">
