### PR TITLE
Add a GitHub workflow with basic build checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,33 @@
+name: "CI"
+
+on: {push: {branches: ['**']}, pull_request: {branches: [dev, master]}}
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os.name }}
+    runs-on: ${{ matrix.os.image }}
+
+    strategy:
+      matrix:
+        os:
+          - {image: macos-latest, name: macOS}
+          - {image: ubuntu-latest, name: Linux}
+          - {image: windows-latest, name: Windows}
+      max-parallel: 4
+      fail-fast: false
+
+    steps:
+      - uses: "actions/checkout@main"
+      - uses: "actions/setup-python@main"
+        with:
+          python-version: 3
+      - name: "Install dependencies"
+        run: |
+          python -mpip install --progress-bar=off nox
+          python --version
+          pip --version
+          nox --version
+      - name: "Build"
+        run: "python -m nox"
+        env:
+          PLATFORM: ${{ matrix.os.image }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-etrago/cluster/__pycache__/networkclustering.cpython-36.pyc
--eTraGo.egg-info/*
--src/* 
+**/__pycache__/*
+build/*
+dist/*
+eTraGo.egg-info/*

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,12 @@
-.. image:: https://readthedocs.org/projects/etrago/badge/?version=latest
+|ci| |docs|
+
+.. |ci| image::
+    https://img.shields.io/github/actions/workflow/status
+    /openego/eTraGo/ci.yaml?branch=dev&event=push&label=ci
+    :alt: GitHub Workflow Status
+
+.. |docs| image::
+    https://readthedocs.org/projects/etrago/badge/?version=latest
     :target: http://etrago.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
     :target: http://etrago.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
+.. end-header
+
 eTraGo
 ======
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,33 @@
+from pprint import pformat
+
+import nox
+
+
+def setdefaults(session):
+    session.env["PYTHONUNBUFFERED"] = "yes"
+
+
+@nox.session(python="3")
+def check(session):
+    setdefaults(session)
+    packages = ["Flake8-pyproject"]
+    packages.extend(["black", "flake8", "isort >= 5", "twine"])
+    session.install(*packages)
+    cleaned = [
+        "etrago/cluster/disaggregation.py",
+        "etrago/tools/network.py",
+        "etrago/tools/utilities.py",
+        "noxfile.py",
+        "setup.py",
+    ]
+    assert cleaned == sorted(set(cleaned)), (
+        "The list of cleaned files contains duplicates and/or isn't sorted"
+        " alphabetically."
+        f"\nExpected:\n{pformat(sorted(set(cleaned)))}"
+        f"\nGot:\n{pformat(cleaned)}"
+    )
+    session.run("black", "--check", "--diff", *cleaned)
+    session.run("isort", "--check-only", "--diff", *cleaned)
+    session.run("flake8", *cleaned)
+    session.run("python", "setup.py", "bdist", "bdist_wheel")
+    session.run("twine", "check", "dist/eTraGo*")

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
-import os
+from os.path import dirname, join
+import io
+import re
 
 from setuptools import find_packages, setup
 
@@ -16,11 +18,25 @@ __author__ = (
 )
 
 
+def read(*names, **kwargs):
+    with io.open(
+        join(dirname(__file__), *names),
+        encoding=kwargs.get("encoding", "utf8"),
+    ) as fh:
+        return fh.read()
+
+
 setup(
     name="eTraGo",
     author="DLR VE, ZNES Flensburg",
     author_email="",
     description="electric transmission grid optimization",
+    long_description="{}".format(
+        re.compile("^.. start-badges.*^.. end-header", re.M | re.S).sub(
+            "", read("README.rst")
+        )
+    ),
+    long_description_content_type="text/x-rst",
     version="0.8.0",
     url="https://github.com/openego/eTraGo",
     license="GNU Affero General Public License Version 3 (AGPL-3.0)",
@@ -50,5 +66,5 @@ setup(
         "gurobipy": ["gurobipy"],
         "cartopy": ["cartopy", "requests"],
     },
-    package_data={"etrago": [os.path.join("tools", "*.json")]},
+    package_data={"etrago": [join("tools", "*.json")]},
 )


### PR DESCRIPTION
Currently it only checks whether the package can be build without errors and whether files that had `black`, `flake8` and `isort` issued fixed did not regress. But it's really easy to add other checks, like e.g. unit tests.
The most important change here is that when you fix `black`, `flake8` and `isort` issues for a file, you can add it to the list of `cleaned` files in the `check` function in "noxfile.py" and the GitHub actions will make sure that it stays that way.