### PR TITLE
Improve continuous integration workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,3 +52,7 @@ jobs:
         run: "python -m nox -s build"
         env:
           PLATFORM: ${{ matrix.os.image }}
+      - name: "Install the package"
+        run: "python -m nox -s install"
+        env:
+          PLATFORM: ${{ matrix.os.image }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - {image: macos-latest, name: macOS}
           - {image: ubuntu-latest, name: Linux}
           - {image: windows-latest, name: Windows}
+          - {image: macos-latest, name: macOS}
       max-parallel: 4
       fail-fast: false
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,23 @@ jobs:
           python --version
           pip --version
           nox --version
-      - name: "Build"
-        run: "python -m nox"
+      - name: "Run custom checks"
+        run: "python -m nox -s check"
+        env:
+          PLATFORM: ${{ matrix.os.image }}
+      - name: "Check with `black`"
+        run: "python -m nox -s black"
+        env:
+          PLATFORM: ${{ matrix.os.image }}
+      - name: "Check with `flake8`"
+        run: "python -m nox -s flake8"
+        env:
+          PLATFORM: ${{ matrix.os.image }}
+      - name: "Check with `isort`"
+        run: "python -m nox -s isort"
+        env:
+          PLATFORM: ${{ matrix.os.image }}
+      - name: "Build and check for packaging errors"
+        run: "python -m nox -s build"
         env:
           PLATFORM: ${{ matrix.os.image }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on: {push: {branches: ['**']}, pull_request: {branches: [dev, master]}}
 
 jobs:
   build:
-    name: Build on ${{ matrix.os.name }}
+    name: ${{ matrix.os.name }}
     runs-on: ${{ matrix.os.image }}
 
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,12 @@ jobs:
       - uses: "actions/checkout@main"
       - uses: "actions/setup-python@main"
         with:
-          python-version: 3
+          python-version: |
+            3
+            3.8
+            3.9
+            3.10
+            3.11
       - name: "Install dependencies"
         run: |
           python -mpip install --progress-bar=off nox

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 .. |ci| image::
     https://img.shields.io/github/actions/workflow/status
     /openego/eTraGo/ci.yaml?branch=dev&event=push&label=ci
-    :alt: GitHub Workflow Status
+    :alt: Continuous Integration Workflow Status
     :target: https://github.com/openego/eTraGo/actions/workflows/ci.yaml
 
 .. |docs| image::

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,7 @@
     https://img.shields.io/github/actions/workflow/status
     /openego/eTraGo/ci.yaml?branch=dev&event=push&label=ci
     :alt: GitHub Workflow Status
+    :target: https://github.com/openego/eTraGo/actions/workflows/ci.yaml
 
 .. |docs| image::
     https://readthedocs.org/projects/etrago/badge/?version=latest

--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@
 
 .. |docs| image::
     https://readthedocs.org/projects/etrago/badge/?version=latest
-    :target: http://etrago.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
+    :target: http://etrago.readthedocs.io/en/latest/?badge=latest
 
 .. end-header
 

--- a/etrago/tools/network.py
+++ b/etrago/tools/network.py
@@ -107,7 +107,6 @@ class Etrago:
         name="",
         **kwargs,
     ):
-
         self.tool_version = __version__
 
         self.clustering = None
@@ -133,7 +132,6 @@ class Etrago:
         self.busmap = {}
 
         if args is not None:
-
             self.args = args
 
             self.get_args_setting(json_path)
@@ -149,7 +147,6 @@ class Etrago:
             self.check_args()
 
         elif csv_folder_name is not None:
-
             self.get_args_setting(csv_folder_name + "/args.json")
 
             self.network = Network(
@@ -157,7 +154,6 @@ class Etrago:
             )
 
             if self.args["disaggregation"] is not None:
-
                 self.disaggregated_network = Network(
                     csv_folder_name + "/disaggregated_network",
                     name,
@@ -248,7 +244,6 @@ class Etrago:
         return self.filter_links_by_carrier("DC", like=False)
 
     def build_network_from_db(self):
-
         """Function that imports transmission grid from chosen database
 
         Returns

--- a/etrago/tools/utilities.py
+++ b/etrago/tools/utilities.py
@@ -52,7 +52,6 @@ __author__ = "ulfmueller, s3pp, wolfbunke, mariusves, lukasol"
 
 
 def filter_links_by_carrier(self, carrier, like=True):
-
     if isinstance(carrier, str):
         if like:
             df = self.network.links[
@@ -756,7 +755,6 @@ def export_to_csv(self, path):
 
 
 def loading_minimization(network, snapshots):
-
     network.model.number1 = Var(
         network.model.passive_branch_p_index, within=PositiveReals
     )
@@ -1537,7 +1535,6 @@ def convert_capital_costs(self):
 
 
 def find_snapshots(network, carrier, maximum=True, minimum=True, n=3):
-
     """
     Function that returns snapshots with maximum and/or minimum feed-in of
     selected carrier.
@@ -1844,7 +1841,6 @@ def set_line_country_tags(network):
 
 
 def crossborder_capacity_tyndp2020():
-
     from urllib.request import urlretrieve
     import zipfile
 
@@ -1997,7 +1993,6 @@ def crossborder_capacity(self):
             }
 
         elif self.args["foreign_lines"]["capacity"] == "tyndp2020":
-
             cap_per_country = crossborder_capacity_tyndp2020()
 
         else:
@@ -2023,7 +2018,6 @@ def crossborder_capacity(self):
         )
 
         for country in cap_per_country:
-
             index_HV = network.lines[
                 (network.lines.country == country)
                 & (network.lines.v_nom == 110)
@@ -2082,7 +2076,6 @@ def crossborder_capacity(self):
 
 
 def set_branch_capacity(etrago):
-
     """
     Set branch capacity factor of lines and transformers, different factors for
     HV (110kV) and eHV (220kV, 380kV).
@@ -2153,15 +2146,12 @@ def check_args(etrago):
         ), "gridversion does not exist"
 
     if etrago.args["snapshot_clustering"]["active"]:
-
         # typical periods
 
         if etrago.args["snapshot_clustering"]["method"] == "typical_periods":
-
             # typical days
 
             if etrago.args["snapshot_clustering"]["how"] == "daily":
-
                 assert (
                     etrago.args["end_snapshot"]
                     / etrago.args["start_snapshot"]
@@ -2188,7 +2178,6 @@ def check_args(etrago):
             # typical weeks
 
             if etrago.args["snapshot_clustering"]["how"] == "weekly":
-
                 assert (
                     etrago.args["end_snapshot"]
                     / etrago.args["start_snapshot"]
@@ -2214,7 +2203,6 @@ def check_args(etrago):
             # typical months
 
             if etrago.args["snapshot_clustering"]["how"] == "monthly":
-
                 assert (
                     etrago.args["end_snapshot"]
                     / etrago.args["start_snapshot"]
@@ -2299,7 +2287,6 @@ def drop_sectors(self, drop_carriers):
     for one_port in self.network.iterate_components(
         ["Load", "Generator", "Store", "StorageUnit"]
     ):
-
         self.network.mremove(
             one_port.name,
             one_port.df[~one_port.df.bus.isin(self.network.buses.index)].index,
@@ -2308,7 +2295,6 @@ def drop_sectors(self, drop_carriers):
     for two_port in self.network.iterate_components(
         ["Line", "Link", "Transformer"]
     ):
-
         self.network.mremove(
             two_port.name,
             two_port.df[
@@ -2367,7 +2353,6 @@ def adjust_CH4_gen_carriers(self):
     """
 
     if self.args["scn_name"] == "eGon2035":
-
         # Define marginal cost
         marginal_cost_def = {"CH4": 40.9765, "biogas": 25.6}
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -51,7 +51,7 @@ def flake8(session):
     session.run("flake8", *cleaned)
 
 
-@nox.session(python="3")
+@nox.session(python=["3", "3.8", "3.9", "3.10", "3.11"])
 def build(session):
     """Build the package and check for packaging errors."""
     setdefaults(session)

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,14 @@ from pprint import pformat
 
 import nox
 
+cleaned = [
+    "etrago/cluster/disaggregation.py",
+    "etrago/tools/network.py",
+    "etrago/tools/utilities.py",
+    "noxfile.py",
+    "setup.py",
+]
+
 
 def setdefaults(session):
     session.env["PYTHONUNBUFFERED"] = "yes"
@@ -13,13 +21,6 @@ def check(session):
     packages = ["Flake8-pyproject"]
     packages.extend(["black", "flake8", "isort >= 5", "twine"])
     session.install(*packages)
-    cleaned = [
-        "etrago/cluster/disaggregation.py",
-        "etrago/tools/network.py",
-        "etrago/tools/utilities.py",
-        "noxfile.py",
-        "setup.py",
-    ]
     assert cleaned == sorted(set(cleaned)), (
         "The list of cleaned files contains duplicates and/or isn't sorted"
         " alphabetically."

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,18 +17,44 @@ def setdefaults(session):
 
 @nox.session(python="3")
 def check(session):
+    """Run custom checks."""
     setdefaults(session)
-    packages = ["Flake8-pyproject"]
-    packages.extend(["black", "flake8", "isort >= 5", "twine"])
-    session.install(*packages)
     assert cleaned == sorted(set(cleaned)), (
         "The list of cleaned files contains duplicates and/or isn't sorted"
         " alphabetically."
         f"\nExpected:\n{pformat(sorted(set(cleaned)))}"
         f"\nGot:\n{pformat(cleaned)}"
     )
+
+
+@nox.session(python="3")
+def black(session):
+    """Check for happy little style accidents with `black`."""
+    setdefaults(session)
+    session.install("black")
     session.run("black", "--check", "--diff", *cleaned)
+
+
+@nox.session(python="3")
+def isort(session):
+    """Check import ordering with `isort`."""
+    setdefaults(session)
+    session.install("isort >= 5")
     session.run("isort", "--check-only", "--diff", *cleaned)
+
+
+@nox.session(python="3")
+def flake8(session):
+    """Check for happy little style accidents with `flake8`."""
+    setdefaults(session)
+    session.install("Flake8-pyproject", "flake8")
     session.run("flake8", *cleaned)
+
+
+@nox.session(python="3")
+def build(session):
+    """Build the package and check for packaging errors."""
+    setdefaults(session)
+    session.install("twine")
     session.run("python", "setup.py", "bdist", "bdist_wheel")
     session.run("twine", "check", "dist/eTraGo*")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from pprint import pformat
 
 import nox
@@ -58,3 +59,11 @@ def build(session):
     session.install("twine")
     session.run("python", "setup.py", "bdist", "bdist_wheel")
     session.run("twine", "check", "dist/eTraGo*")
+
+
+@nox.session(python=["3", "3.8", "3.9", "3.10", "3.11"])
+def install(session):
+    """Install the package."""
+    setdefaults(session)
+    session.run("python", "-mpip", "install", "--upgrade", "pip")
+    session.run("python", "-mpip", "install", *Path("dist").glob("*.whl"))


### PR DESCRIPTION
With these changes

  - the CI badge is now a link to the GitHub workflow details,
  - the CI badge's alt text is no longer specific to GitHub,
  - the list of `cleaned` files is now a module global variable in "noxfile.py",
  - the CI checks are done in multiple small steps instead of one monolithic one,
  - packaging is checked on multiple Python versions,
  - package installation is now checked, too (and also on multiple versions),
  - the workflow job names are now shorter,
  - the workflow jobs are ordered alphabetically in GitHub's UI (this means Linux comes first, yay ;) ), but most importantly
  - the CI checks pass again, because the `cleaned` files have been reformatted with the most recent version of `black`.