### PR TITLE
Remove fixed version for tsam

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "shapely",
         "sqlalchemy < 2",
         "tilemapbase == 0.4.5",
-        "tsam == 1.1.0",
+        "tsam",
     ],
     extras_require={
         "docs": ["sphinx >= 1.4", "sphinx_rtd_theme"],


### PR DESCRIPTION
Fixes #589 

The installation is already tested, so I don't think it is necessary to do that again. 