### PR TITLE
Add cleaned files to noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -3,7 +3,13 @@ from pprint import pformat
 import nox
 
 cleaned = [
+    "etrago/appl.py",
     "etrago/cluster/disaggregation.py",
+    "etrago/cluster/electrical.py",
+    "etrago/cluster/gas.py",
+    "etrago/cluster/snapshot.py",
+    "etrago/tools/constraints.py",
+    "etrago/tools/io.py",
     "etrago/tools/network.py",
     "etrago/tools/utilities.py",
     "noxfile.py",

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,6 +13,7 @@ cleaned = [
     "etrago/tools/utilities.py",
     "noxfile.py",
     "setup.py",
+    "etrago/tools/plot.py",
 ]
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,6 @@ cleaned = [
     "etrago/cluster/gas.py",
     "etrago/cluster/snapshot.py",
     "etrago/tools/constraints.py",
-    "etrago/tools/io.py",
     "etrago/tools/network.py",
     "etrago/tools/utilities.py",
     "noxfile.py",


### PR DESCRIPTION
I added all files which are already reformatted with `black`, `isort` and `flake8` to the list of files checked by the GitHub actions. 
All other files are not reformatted yet. 

@CarlosEpia @AmeliaNadal @KathiEsterl @pieterhexen: When you updated other files in feature branches, please reformat them and add the name of the adjusted file to this list. 