### PR TITLE
Fix KeyError retrieving marginal costs

### DIFF
--- a/etrago/tools/utilities.py
+++ b/etrago/tools/utilities.py
@@ -2624,12 +2624,7 @@ def adjust_CH4_gen_carriers(self):
             FROM scenario.egon_scenario_parameters
             WHERE name = '{self.args["scn_name"]}';"""
             df = pd.read_sql(sql, engine)
-            # TODO: There might be a bug in here raising a `KeyError`.
-            #       If you encounter it, that means you have live data
-            #       to test against. Please do a `git blame` on these
-            #       lines and follow the hints in the commit message to
-            #       fix the bug.
-            marginal_cost = df["marginal_cost"]
+            marginal_cost = df["gas_parameters"][0]["marginal_cost"]
         except sqlalchemy.exc.ProgrammingError:
             marginal_cost = marginal_cost_def
 


### PR DESCRIPTION
Fixes the following KeyError:

KeyError Traceback (most recent call last)
Cell In[6], line 1
----> 1 etrago.adjust_network()

File ~/virtualenvs/hyBit/git_repos/eTraGo/etrago/tools/network.py:351, in Etrago.adjust_network(self)
347 self.geolocation_buses()
349 self.load_shedding()
--> 351 self.adjust_CH4_gen_carriers()
353 self.set_random_noise(0.01)
355 self.set_q_national_loads(cos_phi=0.9)

File
~/virtualenvs/hyBit/git_repos/eTraGo/etrago/tools/utilities.py:2635, in adjust_CH4_gen_carriers(self)
2629 df = pd.read_sql(sql, engine)
2630 # TODO: There might be a bug in here raising a KeyError. 2631 # If you encounter it, that means you have live data 2632 # to test against. Please do a git blame on these 2633 # lines and follow the hints in the commit message to 2634 # fix the bug.
-> 2635 marginal_cost = df["marginal_cost"]
2636 except sqlalchemy.exc.ProgrammingError:
2637 marginal_cost = marginal_cost_def

File
~/virtualenvs/hyBit/lib/python3.8/site-packages/pandas/core/series.py:981, in Series.getitem(self, key)
978 return self._values[key]
980 elif key_is_scalar:
--> 981 return self._get_value(key)
983 if is_hashable(key):
984 # Otherwise index.get_value will raise InvalidIndexError 985 try:
986 # For labels that don't resolve as scalars like tuples and frozensets

File
~/virtualenvs/hyBit/lib/python3.8/site-packages/pandas/core/series.py:1089, in Series._get_value(self, label, takeable)
1086 return self._values[label]
1088 # Similar to Index.get_value, but we do not fall back to positional -> 1089 loc = self.index.get_loc(label)
1090 return self.index._get_values_for_loc(self, loc, label)

File
~/virtualenvs/hyBit/lib/python3.8/site-packages/pandas/core/indexes/range.py:395, in RangeIndex.get_loc(self, key, method, tolerance) 393 raise KeyError(key) from err
394 self._check_indexing_error(key)
--> 395 raise KeyError(key)
396 return super().get_loc(key, method=method, tolerance=tolerance)

KeyError: 'marginal_cost'