### PR TITLE
Fixes/#667 rtd configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.8"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: doc/conf.py
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ sphinx:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
-  - requirements: requirements-docs.txt
+  - requirements: requirements-doc.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+  - requirements: requirements-docs.txt

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,7 +1,7 @@
 # Packages for read the docs
 # Using single requirments for docs, see:
 # https://github.com/rtfd/readthedocs.org/issues/2070
-sphinx_rtd_theme
+sphinx_rtd_theme == 1.3.0
 pypsa == 0.20.1
 numpydoc
 sqlalchemy
@@ -10,3 +10,4 @@ matplotlib
 nbsphinx
 saio
 pyomo != 6.4.3
+sphinx


### PR DESCRIPTION
Fixes #667 

RTD is running again on this branch. 
I added the required `.readthedocs.yaml `file. 
Without fixing the version of `sphinx_rtd_theme` I run into this error: 

```
[2Kwriting output... [  8%] about

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/etrago/envs/fixes-667-rtd-configuration-file/lib/python3.8/site-packages/sphinx/builders/html/__init__.py", line 1098, in handle_page
    output = self.templates.render(templatename, ctx)
  File "/home/docs/checkouts/readthedocs.org/user_builds/etrago/envs/fixes-667-rtd-configuration-file/lib/python3.8/site-packages/readthedocs_ext/readthedocs.py", line 181, in rtd_render
    content = old_render(template, render_context)
  File "/home/docs/checkouts/readthedocs.org/user_builds/etrago/envs/fixes-667-rtd-configuration-file/lib/python3.8/site-packages/sphinx/jinja2glue.py", line 196, in render
    return self.environment.get_template(template).render(context)
  File "/home/docs/checkouts/readthedocs.org/user_builds/etrago/envs/fixes-667-rtd-configuration-file/lib/python3.8/site-packages/jinja2/environment.py", line 1291, in render
    self.environment.handle_exception()
  File "/home/docs/checkouts/readthedocs.org/user_builds/etrago/envs/fixes-667-rtd-configuration-file/lib/python3.8/site-packages/jinja2/environment.py", line 925, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/home/docs/checkouts/readthedocs.org/user_builds/etrago/envs/fixes-667-rtd-configuration-file/lib/python3.8/site-packages/sphinx/themes/basic/page.html", line 10, in top-level template code
    {%- extends "layout.html" %}
  File "/home/docs/checkouts/readthedocs.org/user_builds/etrago/envs/fixes-667-rtd-configuration-file/lib/python3.8/site-packages/sphinx_rtd_theme/layout.html", line 67, in top-level template code
    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
jinja2.exceptions.UndefinedError: 'style' is undefined

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/etrago/envs/fixes-667-rtd-configuration-file/lib/python3.8/site-packages/sphinx/cmd/build.py", line 290, in build_main
    app.build(args.force_all, args.filenames)
  File "/home/docs/checkouts/readthedocs.org/user_builds/etrago/envs/fixes-667-rtd-configuration-file/lib/python3.8/site-packages/sphinx/application.py", line 351, in build
    self.builder.build_update()
  File "/home/docs/checkouts/readthedocs.org/user_builds/etrago/envs/fixes-667-rtd-configuration-file/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 290, in build_update
    self.build(to_build,
  File "/home/docs/checkouts/readthedocs.org/user_builds/etrago/envs/fixes-667-rtd-configuration-file/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 360, in build
    self.write(docnames, list(updated_docnames), method)
  File "/home/docs/checkouts/readthedocs.org/user_builds/etrago/envs/fixes-667-rtd-configuration-file/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 567, in write
    self._write_serial(sorted(docnames))
  File "/home/docs/checkouts/readthedocs.org/user_builds/etrago/envs/fixes-667-rtd-configuration-file/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 577, in _write_serial
    self.write_doc(docname, doctree)
  File "/home/docs/checkouts/readthedocs.org/user_builds/etrago/envs/fixes-667-rtd-configuration-file/lib/python3.8/site-packages/sphinx/builders/html/__init__.py", line 675, in write_doc
    self.handle_page(docname, ctx, event_arg=doctree)
  File "/home/docs/checkouts/readthedocs.org/user_builds/etrago/envs/fixes-667-rtd-configuration-file/lib/python3.8/site-packages/sphinx/builders/html/__init__.py", line 1105, in handle_page
    raise ThemeError(__("An error happened in rendering the page %s.\nReason: %r") %
sphinx.errors.ThemeError: An error happened in rendering the page about.
Reason: UndefinedError("'style' is undefined")

Theme error:
An error happened in rendering the page about.
Reason: UndefinedError("'style' is undefined")
```
Fixing the `sphinx_rtd_theme` version to 1.3.0 (the one I used locally), solved the problem. I don't really know why this solved the problem, but I will try to find out. 