### PR TITLE
Avoid creation of temporary file

### DIFF
--- a/etrago/cluster/spatial.py
+++ b/etrago/cluster/spatial.py
@@ -422,7 +422,6 @@ def busmap_by_shortest_path(etrago, fromlvl, tolvl, cpu_cores=4):
     chunksize = ceil(len(ppaths) / cpu_cores)
     container = p.starmap(shortest_path, gen(ppaths, chunksize, M))
     df = pd.concat(container)
-    dump(df, open("df.p", "wb"))
 
     # post processing
     df.sort_index(inplace=True)
@@ -654,7 +653,6 @@ def dijkstras_algorithm(buses, connections, medoid_idx, cpu_cores):
     chunksize = ceil(len(ppathss) / cpu_cores)
     container = p.starmap(shortest_path, gen(ppathss, chunksize, M))
     df = pd.concat(container)
-    dump(df, open("df.p", "wb"))
 
     # assignment of data points to closest k-medoids centers
     df["path_length"] = pd.to_numeric(df["path_length"])

--- a/etrago/cluster/spatial.py
+++ b/etrago/cluster/spatial.py
@@ -25,7 +25,6 @@ import os
 if "READTHEDOCS" not in os.environ:
     from itertools import product
     from math import ceil
-    from pickle import dump
     import logging
     import multiprocessing as mp
 


### PR DESCRIPTION
The creation of files during clustering was proved to be not necessary. This PR avoid creating them. It was already tested.