### PR TITLE
Fix clustering of h2_grid nodes

### DIFF
--- a/etrago/cluster/gas.py
+++ b/etrago/cluster/gas.py
@@ -355,7 +355,7 @@ def gas_postprocessing(etrago, busmap, medoid_idx=None):
                 + "_result.csv"
             )
 
-    if "H2" in etrago.network.buses.carrier.unique():
+    if "H2_grid" in etrago.network.buses.carrier.unique():
         busmap = get_h2_clusters(etrago, busmap)
 
     # Add all other buses to busmap

--- a/etrago/tools/network.py
+++ b/etrago/tools/network.py
@@ -354,7 +354,7 @@ class Etrago:
 
         self.decommissioning()
 
-        if "H2" in self.network.buses.carrier:
+        if "H2_grid" in self.network.buses.carrier.unique():
             self.add_ch4_h2_correspondence()
 
         logger.info("Imported network from db")


### PR DESCRIPTION
Look for "H2_grid" carrier in network.buses. Before this change, the H2_grid nodes were not clustered at all since "H2" was never in the list of carriers