### PR TITLE
Limit pandas version to < 2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "loguru",
         "matplotlib >= 3.0.3",
         "oedialect",
+        "pandas < 2.2",
         "pypsa == 0.26.2",
         "rtree",
         "saio",


### PR DESCRIPTION
fixes #728 

In version 2.2.0 the driver used in the read_sql function was changed. Our code is so far not compatible to these changes, which is why I downgrade to an older pandas version.