### PR TITLE
Update python version to 3.10 in the documentaion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ you create a virtual environment (where you like it) and activate it:
 
 .. code-block:: bash
 
-   $ virtualenv venv --clear -p python3.8
+   $ virtualenv venv --clear -p python3.10
    $ source venv/bin/activate
    $ cd venv
 

--- a/doc/developer_notes.rst
+++ b/doc/developer_notes.rst
@@ -15,7 +15,7 @@ Installation for Developers
 
 .. code-block:: bash
 
-   $ virtualenv --clear -p python3.8  etrago``
+   $ virtualenv --clear -p python3.10  etrago``
    $ cd etrago/
    $ source bin/activate
    

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -20,7 +20,7 @@ you create a virtual environment (where you like it) and activate it:
 
 .. code-block:: bash
 
-   $ virtualenv venv --clear -p python3.8
+   $ virtualenv venv --clear -p python3.10
    $ source venv/bin/activate
    $ cd venv
 
@@ -40,14 +40,14 @@ Windows or Mac OSX users
 ========================
 
 For Windows and/or Mac OSX user we highly recommend to install and use Anaconda
-for your Python3 installation. First install Conda including python 3.8 or
+for your Python3 installation. First install Conda including python 3.10 or
 higher version from https://www.anaconda.com/download/ and open an anaconda
 prompt as administrator and run:
 
 .. code-block:: bash
 
   $ conda config --add channels conda-forge
-  $ conda create -n etrago_env python=3.8
+  $ conda create -n etrago_env python=3.10
   $ conda activate etrago_env
   $ pip install eTraGo
 


### PR DESCRIPTION
Fixes #718 

Since the last pypsa update to 0.26.2, eTraGo needs python>=3.10