### PR TITLE
Drop upper version limit for tables package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,4 +54,5 @@ jobs:
       - name: "Install the package"
         run: "python -m nox -s install"
         env:
+          PYTHONUNBUFFERED: "1"  # Ensure Python output is unbuffered
           PLATFORM: ${{ matrix.os.image }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,25 +1,30 @@
 name: "CI"
 
-on: 
-  push: 
-    branches: ['**']
-  pull_request: 
-    branches: [dev, master]
+on: {push: {branches: ['**']}, pull_request: {branches: [dev, master]}}
 
 jobs:
-  linux:
-    name: Linux
-    runs-on: ubuntu-latest
+  build:
+    name: ${{ matrix.os.name }}
+    runs-on: ${{ matrix.os.image }}
 
     strategy:
       matrix:
-        python-version: [3, 3.9, "3.10", 3.11]
+        os:
+          - {image: ubuntu-latest, name: Linux}
+          - {image: windows-latest, name: Windows}
+          - {image: macos-latest, name: macOS}
+      max-parallel: 4
+      fail-fast: false
 
     steps:
       - uses: "actions/checkout@main"
       - uses: "actions/setup-python@main"
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: |
+            3
+            3.9
+            3.10
+            3.11
       - name: "Install dependencies"
         run: |
           python -mpip install --progress-bar=off nox
@@ -28,77 +33,25 @@ jobs:
           nox --version
       - name: "Run custom checks"
         run: "python -m nox -s check"
+        env:
+          PLATFORM: ${{ matrix.os.image }}
       - name: "Check with `black`"
         run: "python -m nox -s black"
+        env:
+          PLATFORM: ${{ matrix.os.image }}
       - name: "Check with `flake8`"
         run: "python -m nox -s flake8"
+        env:
+          PLATFORM: ${{ matrix.os.image }}
       - name: "Check with `isort`"
         run: "python -m nox -s isort"
+        env:
+          PLATFORM: ${{ matrix.os.image }}
       - name: "Build and check for packaging errors"
         run: "python -m nox -s build"
+        env:
+          PLATFORM: ${{ matrix.os.image }}
       - name: "Install the package"
         run: "python -m nox -s install"
-
-  windows:
-    name: Windows
-    runs-on: windows-latest
-
-    strategy:
-      matrix:
-        python-version: [3, 3.9, "3.10", 3.11]
-
-    steps:
-      - uses: "actions/checkout@main"
-      - uses: "actions/setup-python@main"
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: "Install dependencies"
-        run: |
-          python -mpip install --progress-bar=off nox
-          python --version
-          pip --version
-          nox --version
-      - name: "Run custom checks"
-        run: "python -m nox -s check"
-      - name: "Check with `black`"
-        run: "python -m nox -s black"
-      - name: "Check with `flake8`"
-        run: "python -m nox -s flake8"
-      - name: "Check with `isort`"
-        run: "python -m nox -s isort"
-      - name: "Build and check for packaging errors"
-        run: "python -m nox -s build"
-      - name: "Install the package"
-        run: "python -m nox -s install"
-
-  macos:
-    name: macOS
-    runs-on: macos-latest
-
-    strategy:
-      matrix:
-        python-version: [3, "3.10", 3.11]  # Exclude Python 3.9 here
-
-    steps:
-      - uses: "actions/checkout@main"
-      - uses: "actions/setup-python@main"
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: "Install dependencies"
-        run: |
-          python -mpip install --progress-bar=off nox
-          python --version
-          pip --version
-          nox --version
-      - name: "Run custom checks"
-        run: "python -m nox -s check"
-      - name: "Check with `black`"
-        run: "python -m nox -s black"
-      - name: "Check with `flake8`"
-        run: "python -m nox -s flake8"
-      - name: "Check with `isort`"
-        run: "python -m nox -s isort"
-      - name: "Build and check for packaging errors"
-        run: "python -m nox -s build"
-      - name: "Install the package"
-        run: "python -m nox -s install"
+        env:
+          PLATFORM: ${{ matrix.os.image }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
           - {image: ubuntu-latest, name: Linux}
           - {image: windows-latest, name: Windows}
           - {image: macos-latest, name: macOS}
-        python-version: [3.9, 3.10, 3.11]
+        python-version: [3, 3.9, "3.10", 3.11]
         exclude:
           - os: {image: macos-latest, name: macOS}
             python-version: 3.9

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,22 +7,13 @@ on:
     branches: [dev, master]
 
 jobs:
-  build:
-    name: ${{ matrix.os.name }}
-    runs-on: ${{ matrix.os.image }}
+  linux:
+    name: Linux
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        os:
-          - {image: ubuntu-latest, name: Linux}
-          - {image: windows-latest, name: Windows}
-          - {image: macos-latest, name: macOS}
         python-version: [3, 3.9, "3.10", 3.11]
-        exclude:
-          - os: {image: macos-latest, name: macOS}
-            python-version: 3.9
-      max-parallel: 4
-      fail-fast: false
 
     steps:
       - uses: "actions/checkout@main"
@@ -37,25 +28,77 @@ jobs:
           nox --version
       - name: "Run custom checks"
         run: "python -m nox -s check"
-        env:
-          PLATFORM: ${{ matrix.os.image }}
       - name: "Check with `black`"
         run: "python -m nox -s black"
-        env:
-          PLATFORM: ${{ matrix.os.image }}
       - name: "Check with `flake8`"
         run: "python -m nox -s flake8"
-        env:
-          PLATFORM: ${{ matrix.os.image }}
       - name: "Check with `isort`"
         run: "python -m nox -s isort"
-        env:
-          PLATFORM: ${{ matrix.os.image }}
       - name: "Build and check for packaging errors"
         run: "python -m nox -s build"
-        env:
-          PLATFORM: ${{ matrix.os.image }}
       - name: "Install the package"
         run: "python -m nox -s install"
-        env:
-          PLATFORM: ${{ matrix.os.image }}
+
+  windows:
+    name: Windows
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        python-version: [3, 3.9, "3.10", 3.11]
+
+    steps:
+      - uses: "actions/checkout@main"
+      - uses: "actions/setup-python@main"
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: "Install dependencies"
+        run: |
+          python -mpip install --progress-bar=off nox
+          python --version
+          pip --version
+          nox --version
+      - name: "Run custom checks"
+        run: "python -m nox -s check"
+      - name: "Check with `black`"
+        run: "python -m nox -s black"
+      - name: "Check with `flake8`"
+        run: "python -m nox -s flake8"
+      - name: "Check with `isort`"
+        run: "python -m nox -s isort"
+      - name: "Build and check for packaging errors"
+        run: "python -m nox -s build"
+      - name: "Install the package"
+        run: "python -m nox -s install"
+
+  macos:
+    name: macOS
+    runs-on: macos-latest
+
+    strategy:
+      matrix:
+        python-version: [3, "3.10", 3.11]  # Exclude Python 3.9 here
+
+    steps:
+      - uses: "actions/checkout@main"
+      - uses: "actions/setup-python@main"
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: "Install dependencies"
+        run: |
+          python -mpip install --progress-bar=off nox
+          python --version
+          pip --version
+          nox --version
+      - name: "Run custom checks"
+        run: "python -m nox -s check"
+      - name: "Check with `black`"
+        run: "python -m nox -s black"
+      - name: "Check with `flake8`"
+        run: "python -m nox -s flake8"
+      - name: "Check with `isort`"
+        run: "python -m nox -s isort"
+      - name: "Build and check for packaging errors"
+        run: "python -m nox -s build"
+      - name: "Install the package"
+        run: "python -m nox -s install"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,24 +1,19 @@
 name: "CI"
 
-on: {push: {branches: ['**']}, pull_request: {branches: [dev, master]}}
+on: 
+  push: 
+    branches: ['**']
+  pull_request: 
+    branches: [dev, master]
 
 jobs:
-  build:
-    name: ${{ matrix.os.name }} - Python ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os.image }}
+  linux:
+    name: Linux
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        os:
-          - {image: ubuntu-latest, name: Linux}
-          - {image: windows-latest, name: Windows}
-          - {image: macos-latest, name: macOS}
         python-version: [3, 3.9, "3.10", 3.11]
-        exclude:
-          - os: {image: macos-latest, name: macOS}
-            python-version: 3.9
-      max-parallel: 4
-      fail-fast: false
 
     steps:
       - uses: "actions/checkout@main"
@@ -33,25 +28,77 @@ jobs:
           nox --version
       - name: "Run custom checks"
         run: "python -m nox -s check"
-        env:
-          PLATFORM: ${{ matrix.os.image }}
       - name: "Check with `black`"
         run: "python -m nox -s black"
-        env:
-          PLATFORM: ${{ matrix.os.image }}
       - name: "Check with `flake8`"
         run: "python -m nox -s flake8"
-        env:
-          PLATFORM: ${{ matrix.os.image }}
       - name: "Check with `isort`"
         run: "python -m nox -s isort"
-        env:
-          PLATFORM: ${{ matrix.os.image }}
       - name: "Build and check for packaging errors"
         run: "python -m nox -s build"
-        env:
-          PLATFORM: ${{ matrix.os.image }}
       - name: "Install the package"
         run: "python -m nox -s install"
-        env:
-          PLATFORM: ${{ matrix.os.image }}
+
+  windows:
+    name: Windows
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        python-version: [3, 3.9, "3.10", 3.11]
+
+    steps:
+      - uses: "actions/checkout@main"
+      - uses: "actions/setup-python@main"
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: "Install dependencies"
+        run: |
+          python -mpip install --progress-bar=off nox
+          python --version
+          pip --version
+          nox --version
+      - name: "Run custom checks"
+        run: "python -m nox -s check"
+      - name: "Check with `black`"
+        run: "python -m nox -s black"
+      - name: "Check with `flake8`"
+        run: "python -m nox -s flake8"
+      - name: "Check with `isort`"
+        run: "python -m nox -s isort"
+      - name: "Build and check for packaging errors"
+        run: "python -m nox -s build"
+      - name: "Install the package"
+        run: "python -m nox -s install"
+
+  macos:
+    name: macOS
+    runs-on: macos-latest
+
+    strategy:
+      matrix:
+        python-version: [3, "3.10", 3.11]  # Exclude Python 3.9 here
+
+    steps:
+      - uses: "actions/checkout@main"
+      - uses: "actions/setup-python@main"
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: "Install dependencies"
+        run: |
+          python -mpip install --progress-bar=off nox
+          python --version
+          pip --version
+          nox --version
+      - name: "Run custom checks"
+        run: "python -m nox -s check"
+      - name: "Check with `black`"
+        run: "python -m nox -s black"
+      - name: "Check with `flake8`"
+        run: "python -m nox -s flake8"
+      - name: "Check with `isort`"
+        run: "python -m nox -s isort"
+      - name: "Build and check for packaging errors"
+        run: "python -m nox -s build"
+      - name: "Install the package"
+        run: "python -m nox -s install"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on: {push: {branches: ['**']}, pull_request: {branches: [dev, master]}}
 
 jobs:
   build:
-    name: ${{ matrix.os.name }}
+    name: ${{ matrix.os.name }} - Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os.image }}
 
     strategy:
@@ -13,6 +13,10 @@ jobs:
           - {image: ubuntu-latest, name: Linux}
           - {image: windows-latest, name: Windows}
           - {image: macos-latest, name: macOS}
+        python-version: [3, 3.9, 3.10, 3.11]
+        exclude:
+          - os: {image: macos-latest, name: macOS}
+            python-version: 3.9
       max-parallel: 4
       fail-fast: false
 
@@ -20,11 +24,7 @@ jobs:
       - uses: "actions/checkout@main"
       - uses: "actions/setup-python@main"
         with:
-          python-version: |
-            3
-            3.9
-            3.10
-            3.11
+          python-version: ${{ matrix.python-version }}
       - name: "Install dependencies"
         run: |
           python -mpip install --progress-bar=off nox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
           - {image: ubuntu-latest, name: Linux}
           - {image: windows-latest, name: Windows}
           - {image: macos-latest, name: macOS}
-        python-version: [3, 3.9, 3.10, 3.11]
+        python-version: [3.9, 3.10, 3.11]
         exclude:
           - os: {image: macos-latest, name: macOS}
             python-version: 3.9

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,13 +7,22 @@ on:
     branches: [dev, master]
 
 jobs:
-  linux:
-    name: Linux
-    runs-on: ubuntu-latest
+  build:
+    name: ${{ matrix.os.name }}
+    runs-on: ${{ matrix.os.image }}
 
     strategy:
       matrix:
+        os:
+          - {image: ubuntu-latest, name: Linux}
+          - {image: windows-latest, name: Windows}
+          - {image: macos-latest, name: macOS}
         python-version: [3, 3.9, "3.10", 3.11]
+        exclude:
+          - os: {image: macos-latest, name: macOS}
+            python-version: 3.9
+      max-parallel: 4
+      fail-fast: false
 
     steps:
       - uses: "actions/checkout@main"
@@ -28,77 +37,25 @@ jobs:
           nox --version
       - name: "Run custom checks"
         run: "python -m nox -s check"
+        env:
+          PLATFORM: ${{ matrix.os.image }}
       - name: "Check with `black`"
         run: "python -m nox -s black"
+        env:
+          PLATFORM: ${{ matrix.os.image }}
       - name: "Check with `flake8`"
         run: "python -m nox -s flake8"
+        env:
+          PLATFORM: ${{ matrix.os.image }}
       - name: "Check with `isort`"
         run: "python -m nox -s isort"
+        env:
+          PLATFORM: ${{ matrix.os.image }}
       - name: "Build and check for packaging errors"
         run: "python -m nox -s build"
+        env:
+          PLATFORM: ${{ matrix.os.image }}
       - name: "Install the package"
         run: "python -m nox -s install"
-
-  windows:
-    name: Windows
-    runs-on: windows-latest
-
-    strategy:
-      matrix:
-        python-version: [3, 3.9, "3.10", 3.11]
-
-    steps:
-      - uses: "actions/checkout@main"
-      - uses: "actions/setup-python@main"
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: "Install dependencies"
-        run: |
-          python -mpip install --progress-bar=off nox
-          python --version
-          pip --version
-          nox --version
-      - name: "Run custom checks"
-        run: "python -m nox -s check"
-      - name: "Check with `black`"
-        run: "python -m nox -s black"
-      - name: "Check with `flake8`"
-        run: "python -m nox -s flake8"
-      - name: "Check with `isort`"
-        run: "python -m nox -s isort"
-      - name: "Build and check for packaging errors"
-        run: "python -m nox -s build"
-      - name: "Install the package"
-        run: "python -m nox -s install"
-
-  macos:
-    name: macOS
-    runs-on: macos-latest
-
-    strategy:
-      matrix:
-        python-version: [3, "3.10", 3.11]  # Exclude Python 3.9 here
-
-    steps:
-      - uses: "actions/checkout@main"
-      - uses: "actions/setup-python@main"
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: "Install dependencies"
-        run: |
-          python -mpip install --progress-bar=off nox
-          python --version
-          pip --version
-          nox --version
-      - name: "Run custom checks"
-        run: "python -m nox -s check"
-      - name: "Check with `black`"
-        run: "python -m nox -s black"
-      - name: "Check with `flake8`"
-        run: "python -m nox -s flake8"
-      - name: "Check with `isort`"
-        run: "python -m nox -s isort"
-      - name: "Build and check for packaging errors"
-        run: "python -m nox -s build"
-      - name: "Install the package"
-        run: "python -m nox -s install"
+        env:
+          PLATFORM: ${{ matrix.os.image }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -68,7 +68,9 @@ def build(session):
     current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
     # Skip the session if it doesn't match the current CI Python version
     if session.python and session.python != current_version:
-        session.skip(f"Skipping tests for Python {session.python} since the current Python version is {current_version}.")
+        session.skip(
+            f"Skipping tests for Python {session.python} since the current Python version is {current_version}."
+        )
     setdefaults(session)
     session.install("twine")
     session.run("python", "setup.py", "bdist", "bdist_wheel")
@@ -81,7 +83,9 @@ def install(session):
     current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
     # Skip the session if it doesn't match the current CI Python version
     if session.python and session.python != current_version:
-        session.skip(f"Skipping tests for Python {session.python} since the current Python version is {current_version}.")
+        session.skip(
+            f"Skipping tests for Python {session.python} since the current Python version is {current_version}."
+        )
     setdefaults(session)
     session.env["SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL"] = "False"
     session.run("python", "-mpip", "install", "--upgrade", "pip")

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from pprint import pformat
 
 import nox
+import sys
 
 cleaned = [
     "etrago/cluster/disaggregation.py",
@@ -69,7 +70,8 @@ def build(session):
     # Skip the session if it doesn't match the current CI Python version
     if session.python and session.python != current_version:
         session.skip(
-            f"Skipping tests for Python {session.python} since the current Python version is {current_version}."
+            f"""Skipping tests for Python {session.python} since the
+            current Python version is {current_version}."""
         )
     setdefaults(session)
     session.install("twine")
@@ -84,7 +86,8 @@ def install(session):
     # Skip the session if it doesn't match the current CI Python version
     if session.python and session.python != current_version:
         session.skip(
-            f"Skipping tests for Python {session.python} since the current Python version is {current_version}."
+            f"""Skipping tests for Python {session.python} since the
+            current Python version is {current_version}."""
         )
     setdefaults(session)
     session.env["SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL"] = "False"

--- a/noxfile.py
+++ b/noxfile.py
@@ -70,6 +70,7 @@ def build(session):
     # Get the current Python version and OS
     current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
     current_os = platform.system()
+    print(f"Running install on Python {current_version} and OS {current_os}")
 
     # Check if the current session is Python 3.9 on macOS and skip
     if current_version == "3.9" and current_os == "Darwin":
@@ -87,6 +88,7 @@ def install(session):
     # Get the current Python version and OS
     current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
     current_os = platform.system()
+    print(f"Running install on Python {current_version} and OS {current_os}")
 
     # Check if the current session is Python 3.9 on macOS and skip
     if current_version == "3.9" and current_os == "Darwin":

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from pprint import pformat
 import platform
-import sys
 
 import nox
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from pprint import pformat
+import platform
 import sys
 
 import nox
@@ -66,13 +67,14 @@ def flake8(session):
 @nox.session(python=["3", "3.9", "3.10", "3.11"])
 def build(session):
     """Build the package and check for packaging errors."""
+    # Get the current Python version and OS
     current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-    # Skip the session if it doesn't match the current CI Python version
-    if session.python and session.python != current_version:
-        session.skip(
-            f"""Skipping tests for Python {session.python} since the
-            current Python version is {current_version}."""
-        )
+    current_os = platform.system()
+
+    # Check if the current session is Python 3.9 on macOS and skip
+    if current_version == "3.9" and current_os == "Darwin":
+        session.skip("Skipping tests for Python 3.9 on macOS")
+
     setdefaults(session)
     session.install("twine")
     session.run("python", "setup.py", "bdist", "bdist_wheel")
@@ -82,13 +84,14 @@ def build(session):
 @nox.session(python=["3", "3.9", "3.10", "3.11"])
 def install(session):
     """Install the package."""
+    # Get the current Python version and OS
     current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-    # Skip the session if it doesn't match the current CI Python version
-    if session.python and session.python != current_version:
-        session.skip(
-            f"""Skipping tests for Python {session.python} since the
-            current Python version is {current_version}."""
-        )
+    current_os = platform.system()
+
+    # Check if the current session is Python 3.9 on macOS and skip
+    if current_version == "3.9" and current_os == "Darwin":
+        session.skip("Skipping tests for Python 3.9 on macOS")
+
     setdefaults(session)
     session.env["SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL"] = "False"
     session.run("python", "-mpip", "install", "--upgrade", "pip")

--- a/noxfile.py
+++ b/noxfile.py
@@ -68,7 +68,7 @@ def flake8(session):
 def build(session):
     """Build the package and check for packaging errors."""
     # Get the current Python version and OS
-    current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    current_version = session.python if session.python else "unknown"
     current_os = platform.system()
     print(f"Running install on Python {current_version} and OS {current_os}")
 
@@ -86,7 +86,7 @@ def build(session):
 def install(session):
     """Install the package."""
     # Get the current Python version and OS
-    current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    current_version = session.python if session.python else "unknown"
     current_os = platform.system()
     print(f"Running install on Python {current_version} and OS {current_os}")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -65,6 +65,10 @@ def flake8(session):
 @nox.session(python=["3", "3.9", "3.10", "3.11"])
 def build(session):
     """Build the package and check for packaging errors."""
+    current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    # Skip the session if it doesn't match the current CI Python version
+    if session.python and session.python != current_version:
+        session.skip(f"Skipping tests for Python {session.python} since the current Python version is {current_version}.")
     setdefaults(session)
     session.install("twine")
     session.run("python", "setup.py", "bdist", "bdist_wheel")
@@ -74,6 +78,10 @@ def build(session):
 @nox.session(python=["3", "3.9", "3.10", "3.11"])
 def install(session):
     """Install the package."""
+    current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    # Skip the session if it doesn't match the current CI Python version
+    if session.python and session.python != current_version:
+        session.skip(f"Skipping tests for Python {session.python} since the current Python version is {current_version}.")
     setdefaults(session)
     session.env["SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL"] = "False"
     session.run("python", "-mpip", "install", "--upgrade", "pip")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 from pprint import pformat
+import sys
 
 import nox
-import sys
 
 cleaned = [
     "etrago/cluster/disaggregation.py",

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "setuptools >= 54.2.0",
         "shapely",
         "sqlalchemy < 2",
-        "tables < 3.9",
+        "tables",
         "tilemapbase == 0.4.5",
         "tsam",
     ],


### PR DESCRIPTION
The limit was needed when using python3.8, which is not supported anymore.

Fixes #753 